### PR TITLE
Mouvement du tank : collisions par grille et glissement le long des murs

### DIFF
--- a/e2e/movement.spec.ts
+++ b/e2e/movement.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+
+// La déclaration de `window.__tanks` vit dans src/client/debug-bridge.ts.
+import '../src/client/debug-bridge';
+
+/**
+ * Les tests unitaires vérifient déjà la physique du déplacement. Ceux-ci
+ * vérifient la chaîne complète — clavier, souris, échantillonnage, simulation,
+ * rendu — que rien d'autre ne couvre.
+ */
+
+/** Lit la position du tank du joueur dans l'état simulé. */
+async function tankPosition(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const tank = window.__tanks?.world.tanks[0];
+    if (!tank) throw new Error('aucun tank dans le monde');
+    return { x: tank.x, y: tank.y, turret: tank.turretAngle };
+  });
+}
+
+/** Maintient des touches enfoncées pendant une durée donnée. */
+async function hold(
+  page: import('@playwright/test').Page,
+  keys: string[],
+  milliseconds: number,
+): Promise<void> {
+  for (const key of keys) await page.keyboard.down(key);
+  await page.waitForTimeout(milliseconds);
+  for (const key of keys) await page.keyboard.up(key);
+}
+
+test('le clavier déplace le tank', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  const before = await tankPosition(page);
+  await hold(page, ['KeyW'], 700);
+  const after = await tankPosition(page);
+
+  // Le tank part vers le haut du couloir vertical dans lequel il apparaît.
+  expect(after.y).toBeLessThan(before.y - 1);
+});
+
+test('le tank longe le mur au lieu de s\'y bloquer', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  const before = await tankPosition(page);
+
+  // Poussée en diagonale contre le mur de droite : l'axe X est bloqué, l'axe Y
+  // doit continuer. C'est le comportement que l'ancienne version n'avait pas —
+  // elle rejetait le déplacement entier et le tank se figeait contre le mur.
+  await hold(page, ['KeyW', 'KeyD'], 1200);
+
+  const after = await tankPosition(page);
+
+  expect(after.x).toBeCloseTo(before.x, 0);
+  expect(after.y).toBeLessThan(before.y - 1.5);
+});
+
+test('relâcher le focus arrête le tank', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  await page.keyboard.down('KeyW');
+  await page.waitForTimeout(300);
+
+  // Sans relâchement au blur, une touche enfoncée au moment où l'on quitte
+  // l'onglet ferait filer le tank indéfiniment.
+  await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+  await page.waitForTimeout(200);
+
+  const settled = await tankPosition(page);
+  await page.waitForTimeout(400);
+  const later = await tankPosition(page);
+
+  await page.keyboard.up('KeyW');
+
+  expect(later.y).toBeCloseTo(settled.y, 3);
+});
+
+test('la souris oriente la tourelle', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  const box = await page.locator('#game').boundingBox();
+  if (!box) throw new Error('canevas introuvable');
+
+  // Le tank apparaît à droite du terrain ; on vise franchement à sa gauche.
+  await page.mouse.move(box.x + 10, box.y + box.height / 2);
+  await page.waitForTimeout(150);
+  const left = await tankPosition(page);
+
+  // Viser vers la gauche donne un angle proche de ±π.
+  expect(Math.abs(left.turret)).toBeGreaterThan(Math.PI / 2);
+
+  await page.mouse.move(box.x + box.width - 10, box.y + box.height - 10);
+  await page.waitForTimeout(150);
+  const downRight = await tankPosition(page);
+
+  // Vers le bas : angle positif (l'axe Y descend à l'écran).
+  expect(downRight.turret).toBeGreaterThan(0);
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -18,17 +18,26 @@ test('la page se charge et peint le canevas sans erreur console', async ({ page 
   const canvas = page.locator('#game');
   await expect(canvas).toBeVisible();
 
-  const dimensions = await canvas.evaluate((element) => ({
-    width: (element as HTMLCanvasElement).width,
-    height: (element as HTMLCanvasElement).height,
-  }));
-  expect(dimensions).toEqual({ width: 800, height: 600 });
+  // La taille du canevas se déduit du terrain chargé, on ne la code donc pas en
+  // dur : chaque mission a ses propres dimensions.
+  const dimensions = await canvas.evaluate((element) => {
+    const grid = window.__tanks?.world.grid;
+    return {
+      actual: {
+        width: (element as HTMLCanvasElement).width,
+        height: (element as HTMLCanvasElement).height,
+      },
+      expected: grid ? { width: grid.width * 32, height: grid.height * 32 } : null,
+    };
+  });
+  expect(dimensions.actual).toEqual(dimensions.expected);
 
   // Le canevas ne doit pas être resté transparent : au moins un pixel opaque.
   const hasPaintedPixels = await canvas.evaluate((element) => {
-    const context = (element as HTMLCanvasElement).getContext('2d');
+    const target = element as HTMLCanvasElement;
+    const context = target.getContext('2d');
     if (!context) return false;
-    const { data } = context.getImageData(0, 0, 800, 600);
+    const { data } = context.getImageData(0, 0, target.width, target.height);
     for (let i = 3; i < data.length; i += 4) {
       if (data[i] !== 0) return true;
     }
@@ -68,11 +77,6 @@ test('la simulation avance à 60 pas par seconde de temps réel', async ({ page 
   expect(ticksPerSecond).toBeLessThan(70);
 });
 
-declare global {
-  interface Window {
-    __tanks?: {
-      world: { tick: number };
-      rates: { ticksPerSecond: number; framesPerSecond: number };
-    };
-  }
-}
+// La déclaration de `window.__tanks` vit dans src/client/debug-bridge.ts :
+// deux `declare global` concurrents pour la même propriété ne compileraient pas.
+import '../src/client/debug-bridge';

--- a/src/client/debug-bridge.ts
+++ b/src/client/debug-bridge.ts
@@ -1,0 +1,39 @@
+/**
+ * Passerelle de diagnostic exposée sur `window`.
+ *
+ * Le jeu se dessine intégralement dans un canevas : il n'y a aucun DOM à
+ * interroger, donc aucun moyen pour un test bout-en-bout de vérifier autre
+ * chose que des pixels. Cette passerelle donne à Playwright un accès en lecture
+ * à l'état simulé.
+ *
+ * Le type est déclaré ici, et ici seulement, pour que le client et les tests
+ * partagent la même définition — deux `declare global` concurrents ne
+ * compileraient pas.
+ */
+
+import type { World } from '@core/state';
+
+/** Cadences mesurées, pour vérifier que la simulation reste indépendante de l'écran. */
+export interface RateProbe {
+  ticks: number;
+  frames: number;
+  ticksPerSecond: number;
+  framesPerSecond: number;
+  windowStartMs: number;
+}
+
+export interface TanksDebugBridge {
+  world: World;
+  rates: RateProbe;
+}
+
+declare global {
+  interface Window {
+    __tanks?: TanksDebugBridge;
+  }
+}
+
+/** Publie la passerelle. Sans effet sur la simulation. */
+export function exposeDebugBridge(bridge: TanksDebugBridge): void {
+  window.__tanks = bridge;
+}

--- a/src/client/input/bindings.ts
+++ b/src/client/input/bindings.ts
@@ -1,0 +1,48 @@
+/**
+ * Correspondance touches → actions.
+ *
+ * Le schéma reprend celui du jeu original transposé au clavier-souris : dans
+ * Tanks!, le stick du nunchuk déplace le tank pendant que le pointeur de la
+ * Wiimote vise indépendamment. Le clavier tient le rôle du stick, la souris
+ * celui du pointeur — c'est la transposition la plus fidèle, et c'était déjà le
+ * choix de l'ancienne version.
+ *
+ * Les dispositions AZERTY (ZQSD) et QWERTY (WASD) sont acceptées simultanément :
+ * elles ne se recouvrent pas, donc aucun conflit.
+ */
+
+export type GameAction = 'up' | 'down' | 'left' | 'right' | 'fire' | 'mine';
+
+/**
+ * Codes physiques de touches, et non caractères produits.
+ *
+ * `KeyboardEvent.code` désigne l'emplacement sur le clavier indépendamment de
+ * la disposition : `KeyW` est la touche en haut à gauche du bloc, qu'elle
+ * imprime « w » en QWERTY ou « z » en AZERTY. On couvre donc les deux mains
+ * sans avoir à détecter la disposition.
+ */
+export const KEY_BINDINGS: Readonly<Record<string, GameAction>> = {
+  KeyW: 'up',
+  KeyZ: 'up',
+  ArrowUp: 'up',
+
+  KeyS: 'down',
+  ArrowDown: 'down',
+
+  KeyA: 'left',
+  KeyQ: 'left',
+  ArrowLeft: 'left',
+
+  KeyD: 'right',
+  ArrowRight: 'right',
+
+  Space: 'fire',
+  KeyE: 'mine',
+  ShiftLeft: 'mine',
+};
+
+/** Boutons de souris. 0 = principal, 2 = secondaire. */
+export const MOUSE_BINDINGS: Readonly<Record<number, GameAction>> = {
+  0: 'fire',
+  2: 'mine',
+};

--- a/src/client/input/sampler.ts
+++ b/src/client/input/sampler.ts
@@ -1,0 +1,117 @@
+/**
+ * Collecte des entrées.
+ *
+ * Le rôle de ce module est de transformer des évènements du navigateur en un
+ * {@link InputCommand} — la seule chose que la simulation accepte, et la seule
+ * chose qui partira sur le réseau en multijoueur (#13).
+ *
+ * C'est délibérément la seule couche qui connaisse le clavier et la souris : la
+ * simulation, elle, ne sait pas d'où viennent les intentions qu'elle applique.
+ */
+
+import type { InputCommand } from '@core/state';
+import { KEY_BINDINGS, MOUSE_BINDINGS } from './bindings';
+import type { GameAction } from './bindings';
+
+/** Convertit une position de pointeur en coordonnées monde. */
+export type PointerToWorld = (clientX: number, clientY: number) => { x: number; y: number };
+
+export class InputSampler {
+  readonly #active = new Set<GameAction>();
+  readonly #target: HTMLElement;
+  readonly #pointerToWorld: PointerToWorld;
+  readonly #disposers: Array<() => void> = [];
+
+  /** Dernière position connue du pointeur, en coordonnées monde. */
+  #aimX = 0;
+  #aimY = 0;
+
+  /** Origine de la visée : le tank, dont la position change à chaque pas. */
+  #originX = 0;
+  #originY = 0;
+
+  constructor(target: HTMLElement, pointerToWorld: PointerToWorld) {
+    this.#target = target;
+    this.#pointerToWorld = pointerToWorld;
+    this.#attach();
+  }
+
+  /**
+   * Renseigne la position du tank piloté.
+   *
+   * L'angle de visée se recalcule à chaque pas depuis cette origine : sans ça,
+   * un tank qui se déplace sous un pointeur immobile garderait un angle périmé.
+   */
+  setAimOrigin(x: number, y: number): void {
+    this.#originX = x;
+    this.#originY = y;
+  }
+
+  /** Construit l'intention correspondant à l'état courant des entrées. */
+  sample(): InputCommand {
+    const moveX = (this.#active.has('right') ? 1 : 0) - (this.#active.has('left') ? 1 : 0);
+    const moveY = (this.#active.has('down') ? 1 : 0) - (this.#active.has('up') ? 1 : 0);
+
+    return {
+      moveX,
+      moveY,
+      aim: Math.atan2(this.#aimY - this.#originY, this.#aimX - this.#originX),
+      fire: this.#active.has('fire'),
+      mine: this.#active.has('mine'),
+    };
+  }
+
+  dispose(): void {
+    for (const dispose of this.#disposers) dispose();
+    this.#disposers.length = 0;
+    this.#active.clear();
+  }
+
+  /* ── Câblage ─────────────────────────────────────────────────────────── */
+
+  #attach(): void {
+    this.#listen(window, 'keydown', (event) => {
+      const action = KEY_BINDINGS[(event as KeyboardEvent).code];
+      if (!action) return;
+      // Sinon la barre d'espace ferait défiler la page sous le jeu.
+      event.preventDefault();
+      this.#active.add(action);
+    });
+
+    this.#listen(window, 'keyup', (event) => {
+      const action = KEY_BINDINGS[(event as KeyboardEvent).code];
+      if (action) this.#active.delete(action);
+    });
+
+    // Perdre le focus pendant qu'une touche est enfoncée laisserait le tank
+    // filer indéfiniment : on relâche tout.
+    this.#listen(window, 'blur', () => this.#active.clear());
+
+    this.#listen(this.#target, 'pointermove', (event) => {
+      const { clientX, clientY } = event as PointerEvent;
+      const world = this.#pointerToWorld(clientX, clientY);
+      this.#aimX = world.x;
+      this.#aimY = world.y;
+    });
+
+    this.#listen(this.#target, 'pointerdown', (event) => {
+      const action = MOUSE_BINDINGS[(event as PointerEvent).button];
+      if (action) this.#active.add(action);
+    });
+
+    // Sur `window` et non sur la cible : un bouton relâché en dehors du canevas
+    // resterait sinon considéré comme enfoncé.
+    this.#listen(window, 'pointerup', (event) => {
+      const action = MOUSE_BINDINGS[(event as PointerEvent).button];
+      if (action) this.#active.delete(action);
+    });
+
+    // Le clic droit sert à poser une mine : pas de menu contextuel.
+    this.#listen(this.#target, 'contextmenu', (event) => event.preventDefault());
+  }
+
+  #listen(target: EventTarget, type: string, handler: (event: Event) => void): void {
+    target.addEventListener(type, handler);
+    this.#disposers.push(() => target.removeEventListener(type, handler));
+  }
+}

--- a/src/client/local/LocalGame.ts
+++ b/src/client/local/LocalGame.ts
@@ -1,0 +1,60 @@
+/**
+ * Partie solo.
+ *
+ * Point important d'architecture : **ce n'est pas un chemin de code parallèle**.
+ * `LocalGame` possède un `World` et appelle le même `tick()` que le serveur
+ * appellera (#13). Le mode solo ne peut donc pas diverger du mode en ligne —
+ * l'ancienne version avait deux implémentations distinctes, et elles avaient
+ * dérivé l'une de l'autre.
+ *
+ * Quand le multijoueur arrivera, la seule différence sera l'origine des
+ * intentions : lues localement ici, reçues par le réseau là-bas.
+ */
+
+import type { InputCommand, Tank, World } from '@core/state';
+import { tick } from '@core/tick';
+import type { TickInputs } from '@core/tick';
+import { captureSnapshot, interpolateSnapshots } from '../render/snapshots';
+import type { RenderSnapshot } from '../render/snapshots';
+
+export class LocalGame {
+  readonly #world: World;
+  readonly #playerTankId: number;
+
+  /** Les deux derniers états, pour interpoler le rendu entre deux pas. */
+  #previous: RenderSnapshot;
+  #current: RenderSnapshot;
+
+  constructor(world: World, playerTankId: number) {
+    this.#world = world;
+    this.#playerTankId = playerTankId;
+    this.#current = captureSnapshot(world);
+    this.#previous = this.#current;
+  }
+
+  get world(): World {
+    return this.#world;
+  }
+
+  get playerTank(): Tank | undefined {
+    return this.#world.tanks.find((tank) => tank.id === this.#playerTankId);
+  }
+
+  /** Avance la simulation d'un pas avec l'intention du joueur. */
+  update(input: InputCommand): void {
+    const inputs: TickInputs = [[this.#playerTankId, input]];
+
+    this.#previous = this.#current;
+    tick(this.#world, inputs);
+    this.#current = captureSnapshot(this.#world);
+  }
+
+  /**
+   * État à dessiner pour la frame courante.
+   *
+   * @param alpha résidu d'interpolation fourni par la boucle à pas fixe
+   */
+  view(alpha: number): RenderSnapshot {
+    return interpolateSnapshots(this.#previous, this.#current, alpha);
+  }
+}

--- a/src/client/local/sandbox.ts
+++ b/src/client/local/sandbox.ts
@@ -1,0 +1,61 @@
+/**
+ * Terrain d'essai.
+ *
+ * Provisoire : les 20 vraies missions arrivent en #12, portées depuis les
+ * tracés de `legacy/src/level.ts`. Celui-ci existe pour éprouver le pilotage —
+ * il réunit volontairement les situations qui mettent le mouvement en défaut :
+ * couloirs d'une tuile, angles rentrants, diagonales à longer, culs-de-sac, et
+ * un trou qu'on doit pouvoir contourner.
+ */
+
+import type { World } from '@core/state';
+import { allocateEntityId, createWorld } from '@core/world';
+import { parseMission } from '@shared/missions/parse';
+
+const SANDBOX = `
+#########################
+#.......................#
+#.###.#####.#####.#####.#
+#.#...#...........#...#.#
+#.#.###.#######.###.#.#.#
+#...#...#XXXXX#...#...#.#
+#.###.#.#HHHHH#.#.#.###.#
+#.....#.#HHHHH#.#.#.....#
+#.###.#.#XXXXX#.#.#.###.#
+#.#...#.........#...#..1#
+#.#.#########.#########.#
+#...#.................#.#
+#.#########.#########.#.#
+#.......................#
+#########################
+`;
+
+/** Construit le monde d'essai et rend l'identifiant du tank du joueur. */
+export function createSandbox(): { world: World; playerTankId: number } {
+  const mission = parseMission(SANDBOX);
+  const spawn = mission.playerSpawns[0]!;
+
+  const world = createWorld({
+    width: mission.grid.width,
+    height: mission.grid.height,
+    seed: 1,
+  });
+  world.grid = mission.grid;
+
+  const playerTankId = allocateEntityId(world);
+  world.tanks.push({
+    id: playerTankId,
+    color: 'player',
+    playerId: 'local',
+    x: spawn.x,
+    y: spawn.y,
+    bodyAngle: 0,
+    turretAngle: 0,
+    alive: true,
+    activeShells: 0,
+    activeMines: 0,
+    reloadTicks: 0,
+  });
+
+  return { world, playerTankId };
+}

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,51 +1,49 @@
 /**
  * Point d'entrée du client.
  *
- * À ce stade (issue #6) il n'y a pas encore de gameplay : ce qui tourne ici est
- * la boucle à pas fixe, et l'affichage sert de vérification visuelle.
+ * Assemble les quatre couches et rien de plus : entrées → simulation → rendu,
+ * cadencées par la boucle à pas fixe. Aucune logique de jeu ici.
  *
- * Le compteur de pas par seconde doit rester collé à 60 quelle que soit la
- * fréquence de l'écran. C'est exactement ce que l'ancienne version ne faisait
- * pas : elle avançait d'un pas par frame, donc 144 pas par seconde sur un écran
- * 144 Hz. Ouvrir cette page sur un écran haute fréquence est le test à l'oeil
- * nu de la correction.
- *
- * Le rendu du terrain arrive en #7.
+ * À ce stade (#7) on peut piloter un tank dans un labyrinthe. Les tirs arrivent
+ * en #8, les mines en #9, les ennemis en #11.
  */
 
-import { TICK_RATE, tick } from '@core/tick';
-import type { TickInputs } from '@core/tick';
-import { createWorld } from '@core/world';
+import { TICK_RATE } from '@core/tick';
+import { exposeDebugBridge } from './debug-bridge';
+import type { RateProbe } from './debug-bridge';
+import { InputSampler } from './input/sampler';
+import { LocalGame } from './local/LocalGame';
+import { createSandbox } from './local/sandbox';
 import { startGameLoop } from './loop';
+import { Canvas2DRenderer } from './render/canvas2d/Canvas2DRenderer';
 
 /**
- * Récupère le canevas et son contexte.
+ * Récupère le canevas.
  *
  * Passer par une fonction au type de retour explicite plutôt que par des
  * `const` en portée de module : le rétrécissement de type après un `if (!x)
- * throw` ne traverse pas les frontières de fonction, et tous les usages dans
- * `render()` redeviendraient nullables.
+ * throw` ne traverse pas les frontières de fonction.
  */
-function mountCanvas(): { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D } {
+function mountCanvas(): HTMLCanvasElement {
   const canvas = document.querySelector<HTMLCanvasElement>('#game');
   if (!canvas) throw new Error('Canevas #game introuvable dans index.html');
-
-  const ctx = canvas.getContext('2d');
-  if (!ctx) throw new Error('Contexte 2D indisponible : le navigateur ne supporte pas Canvas');
-
-  return { canvas, ctx };
+  return canvas;
 }
 
-const { canvas, ctx } = mountCanvas();
+const canvas = mountCanvas();
+const renderer = new Canvas2DRenderer(canvas);
 
-canvas.width = 800;
-canvas.height = 600;
+const { world, playerTankId } = createSandbox();
+const game = new LocalGame(world, playerTankId);
 
-const world = createWorld({ width: 25, height: 19, seed: 1 });
-const NO_INPUTS: TickInputs = [];
+renderer.resize(world.grid);
 
-/** Mesure séparée des deux cadences, pour rendre l'écart visible s'il réapparaît. */
-const rates = {
+const sampler = new InputSampler(canvas, (clientX, clientY) =>
+  renderer.pointerToWorld(clientX, clientY),
+);
+
+/** Diagnostic de cadence, affiché en surimpression. Sans effet sur la simulation. */
+const rates: RateProbe = {
   ticks: 0,
   frames: 0,
   ticksPerSecond: 0,
@@ -53,10 +51,6 @@ const rates = {
   windowStartMs: 0,
 };
 
-/**
- * Le seul endroit du client autorisé à lire l'horloge murale : la mesure de
- * diagnostic. La simulation, elle, ne connaît que `world.tick`.
- */
 function sampleRates(nowMs: number): void {
   if (rates.windowStartMs === 0) rates.windowStartMs = nowMs;
 
@@ -70,50 +64,49 @@ function sampleRates(nowMs: number): void {
   rates.windowStartMs = nowMs;
 }
 
-function render(alpha: number): void {
-  rates.frames++;
-  sampleRates(performance.now());
-
-  ctx.fillStyle = '#2b2118';
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-  ctx.fillStyle = '#d8c9a8';
-  ctx.font = '14px ui-monospace, monospace';
-  ctx.textAlign = 'left';
-
+function drawOverlay(ctx: CanvasRenderingContext2D): void {
   const lines = [
-    `pas de simulation   ${world.tick}`,
-    `pas / seconde       ${rates.ticksPerSecond} (attendu ${TICK_RATE})`,
-    `frames / seconde    ${rates.framesPerSecond}`,
-    `résidu alpha        ${alpha.toFixed(3)}`,
-    `grille              ${world.grid.width} × ${world.grid.height} tuiles`,
+    `pas/s ${rates.ticksPerSecond} (attendu ${TICK_RATE})   frames/s ${rates.framesPerSecond}`,
+    'ZQSD ou WASD ou flèches — souris pour viser',
   ];
 
-  lines.forEach((line, index) => {
-    ctx.fillText(line, 24, 40 + index * 22);
-  });
+  // En bas de l'image : le bandeau ne doit pas masquer le terrain de jeu.
+  // Provisoire — le vrai HUD arrive en #12, le panneau de réglages en #10.
+  const height = 18 * lines.length + 10;
+  const top = ctx.canvas.height - height - 8;
 
-  ctx.fillStyle = '#6f6350';
-  ctx.fillText(
-    'La cadence de simulation doit rester à 60 quelle que soit celle de l’écran.',
-    24,
-    40 + lines.length * 22 + 16,
-  );
+  ctx.save();
+  ctx.fillStyle = 'rgba(20, 14, 8, 0.55)';
+  ctx.fillRect(8, top, 400, height);
+
+  ctx.fillStyle = '#e8dcc0';
+  ctx.font = '12px ui-monospace, monospace';
+  ctx.textBaseline = 'top';
+  lines.forEach((line, index) => ctx.fillText(line, 18, top + 6 + index * 18));
+  ctx.restore();
 }
+
+const overlayCtx = canvas.getContext('2d');
 
 startGameLoop({
   update(): void {
     rates.ticks++;
-    tick(world, NO_INPUTS);
+
+    // La visée se recalcule depuis la position courante du tank : un pointeur
+    // immobile au-dessus d'un tank qui se déplace doit rester visé.
+    const tank = game.playerTank;
+    if (tank) sampler.setAimOrigin(tank.x, tank.y);
+
+    game.update(sampler.sample());
   },
-  render,
+
+  render(alpha): void {
+    rates.frames++;
+    sampleRates(performance.now());
+
+    renderer.draw(world.grid, game.view(alpha));
+    if (overlayCtx) drawOverlay(overlayCtx);
+  },
 });
 
-// Exposé pour les tests bout-en-bout, qui n'ont aucun DOM à interroger : le jeu
-// vit entièrement dans le canevas.
-declare global {
-  interface Window {
-    __tanks?: { world: typeof world; rates: typeof rates };
-  }
-}
-window.__tanks = { world, rates };
+exposeDebugBridge({ world, rates });

--- a/src/client/render/Renderer.ts
+++ b/src/client/render/Renderer.ts
@@ -1,0 +1,38 @@
+/**
+ * Contrat de rendu.
+ *
+ * Le reste du client ne connaît que cette interface. C'est ce qui permettra de
+ * brancher un renderer 3D (#14 et au-delà) sans toucher une ligne de gameplay :
+ * la simulation est en 2D sur un plan, seule la façon de la regarder change.
+ *
+ * Un renderer ne lit jamais le `World` directement — il reçoit un
+ * {@link RenderSnapshot} déjà interpolé. La séparation est stricte : le rendu ne
+ * peut pas, même par accident, modifier l'état simulé.
+ */
+
+import type { Grid } from '@core/state';
+import type { RenderSnapshot } from './snapshots';
+
+export interface Renderer {
+  /**
+   * Adapte la surface de rendu aux dimensions du terrain.
+   * À appeler au chargement d'une mission.
+   */
+  resize(grid: Grid): void;
+
+  /**
+   * Signale que le terrain a changé et que son cache doit être reconstruit.
+   * Appelé quand une mine détruit un bloc (#9).
+   */
+  invalidateTerrain(): void;
+
+  /** Dessine une frame. */
+  draw(grid: Grid, view: RenderSnapshot): void;
+
+  /**
+   * Convertit des coordonnées de pointeur (repère de la fenêtre) en coordonnées
+   * monde, en tuiles. C'est le renderer qui détient la transformation, donc
+   * c'est à lui de l'inverser.
+   */
+  pointerToWorld(clientX: number, clientY: number): { x: number; y: number };
+}

--- a/src/client/render/canvas2d/Canvas2DRenderer.ts
+++ b/src/client/render/canvas2d/Canvas2DRenderer.ts
@@ -1,0 +1,239 @@
+/**
+ * Rendu Canvas 2D, vue du dessus.
+ *
+ * Le terrain est dessiné une fois dans un canevas hors écran puis recopié à
+ * chaque frame : il ne change qu'à la destruction d'un bloc (#9), alors que le
+ * reste est redessiné 60 à 240 fois par seconde.
+ */
+
+import { TileKind } from '@core/state';
+import type { Grid } from '@core/state';
+import { TILE_SIZE_PX, TUNING } from '@core/tuning';
+import { tileAt } from '@core/grid';
+import { BLOCKS, BOARD, TANK_COLORS, darken, lighten } from '../palette';
+import type { Renderer } from '../Renderer';
+import type { RenderSnapshot, TankView } from '../snapshots';
+
+/** Décalage vertical des faces de blocs, qui simule leur épaisseur. */
+const BLOCK_RELIEF_PX = 5;
+
+export class Canvas2DRenderer implements Renderer {
+  readonly #canvas: HTMLCanvasElement;
+  readonly #ctx: CanvasRenderingContext2D;
+
+  /** Cache du terrain. Reconstruit seulement quand la grille change. */
+  #terrain: HTMLCanvasElement | null = null;
+  #terrainStale = true;
+
+  constructor(canvas: HTMLCanvasElement) {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Contexte 2D indisponible');
+
+    this.#canvas = canvas;
+    this.#ctx = ctx;
+  }
+
+  resize(grid: Grid): void {
+    this.#canvas.width = grid.width * TILE_SIZE_PX;
+    this.#canvas.height = grid.height * TILE_SIZE_PX;
+    this.#terrainStale = true;
+  }
+
+  invalidateTerrain(): void {
+    this.#terrainStale = true;
+  }
+
+  pointerToWorld(clientX: number, clientY: number): { x: number; y: number } {
+    // Le canevas est mis à l'échelle par CSS pour tenir dans la fenêtre : on
+    // repasse donc par le rapport entre sa taille affichée et sa résolution
+    // interne, sans quoi la visée dériverait dès que la fenêtre est petite.
+    const bounds = this.#canvas.getBoundingClientRect();
+    const scaleX = this.#canvas.width / bounds.width;
+    const scaleY = this.#canvas.height / bounds.height;
+
+    return {
+      x: ((clientX - bounds.left) * scaleX) / TILE_SIZE_PX,
+      y: ((clientY - bounds.top) * scaleY) / TILE_SIZE_PX,
+    };
+  }
+
+  draw(grid: Grid, view: RenderSnapshot): void {
+    if (this.#terrainStale) this.#buildTerrain(grid);
+    if (this.#terrain) this.#ctx.drawImage(this.#terrain, 0, 0);
+
+    for (const tank of view.tanks) {
+      if (tank.alive) this.#drawTank(tank);
+    }
+  }
+
+  /* ── Terrain ─────────────────────────────────────────────────────────── */
+
+  #buildTerrain(grid: Grid): void {
+    const canvas = document.createElement('canvas');
+    canvas.width = this.#canvas.width;
+    canvas.height = this.#canvas.height;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    this.#drawFloor(ctx, grid);
+
+    // Les ombres d'abord, en une passe séparée : dessinées bloc par bloc, elles
+    // se projetteraient par-dessus les blocs voisins déjà peints.
+    for (let tileY = 0; tileY < grid.height; tileY++) {
+      for (let tileX = 0; tileX < grid.width; tileX++) {
+        const kind = tileAt(grid, tileX, tileY);
+        if (kind === TileKind.Indestructible || kind === TileKind.Destructible) {
+          ctx.fillStyle = BOARD.shadow;
+          ctx.fillRect(
+            tileX * TILE_SIZE_PX + 3,
+            tileY * TILE_SIZE_PX + 4,
+            TILE_SIZE_PX,
+            TILE_SIZE_PX,
+          );
+        }
+      }
+    }
+
+    for (let tileY = 0; tileY < grid.height; tileY++) {
+      for (let tileX = 0; tileX < grid.width; tileX++) {
+        this.#drawTile(ctx, tileAt(grid, tileX, tileY), tileX, tileY);
+      }
+    }
+
+    this.#terrain = canvas;
+    this.#terrainStale = false;
+  }
+
+  #drawFloor(ctx: CanvasRenderingContext2D, grid: Grid): void {
+    ctx.fillStyle = BOARD.floor;
+    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+    // Damier très peu contrasté : il donne l'échelle de la grille sans devenir
+    // le motif dominant de l'image.
+    ctx.fillStyle = BOARD.floorAlternate;
+    for (let tileY = 0; tileY < grid.height; tileY++) {
+      for (let tileX = (tileY % 2); tileX < grid.width; tileX += 2) {
+        ctx.fillRect(tileX * TILE_SIZE_PX, tileY * TILE_SIZE_PX, TILE_SIZE_PX, TILE_SIZE_PX);
+      }
+    }
+  }
+
+  #drawTile(ctx: CanvasRenderingContext2D, kind: TileKind, tileX: number, tileY: number): void {
+    if (kind === TileKind.Empty) return;
+
+    const px = tileX * TILE_SIZE_PX;
+    const py = tileY * TILE_SIZE_PX;
+
+    if (kind === TileKind.Hole) {
+      ctx.fillStyle = BLOCKS.holeRim;
+      ctx.fillRect(px, py, TILE_SIZE_PX, TILE_SIZE_PX);
+      ctx.fillStyle = BLOCKS.holeFloor;
+      ctx.fillRect(px + 2, py + 2, TILE_SIZE_PX - 4, TILE_SIZE_PX - 4);
+      return;
+    }
+
+    const isDestructible = kind === TileKind.Destructible;
+    const face = isDestructible ? BLOCKS.destructibleFace : BLOCKS.indestructibleFace;
+    const top = isDestructible ? BLOCKS.destructibleTop : BLOCKS.indestructibleTop;
+    const edge = isDestructible ? BLOCKS.destructibleEdge : BLOCKS.indestructibleEdge;
+
+    // Flanc, puis dessus décalé vers le haut : le bloc paraît avoir une
+    // épaisseur, comme les blocs de liège posés sur le plateau de l'original.
+    ctx.fillStyle = face;
+    ctx.fillRect(px, py, TILE_SIZE_PX, TILE_SIZE_PX);
+
+    ctx.fillStyle = top;
+    ctx.fillRect(px, py - BLOCK_RELIEF_PX, TILE_SIZE_PX, TILE_SIZE_PX - BLOCK_RELIEF_PX);
+
+    ctx.strokeStyle = edge;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(px + 0.5, py - BLOCK_RELIEF_PX + 0.5, TILE_SIZE_PX - 1, TILE_SIZE_PX - 1);
+
+    // Les blocs cassables portent un grain visible : le joueur doit pouvoir
+    // décider d'un coup d'oeil où poser une mine.
+    if (isDestructible) {
+      ctx.fillStyle = 'rgba(80, 45, 15, 0.22)';
+      for (let i = 0; i < 5; i++) {
+        const dotX = px + 5 + ((i * 11) % (TILE_SIZE_PX - 10));
+        const dotY = py - BLOCK_RELIEF_PX + 6 + ((i * 7) % (TILE_SIZE_PX - 14));
+        ctx.fillRect(dotX, dotY, 3, 3);
+      }
+    }
+  }
+
+  /* ── Tanks ───────────────────────────────────────────────────────────── */
+
+  #drawTank(tank: TankView): void {
+    const ctx = this.#ctx;
+    const size = TUNING.tank.sizeTiles * TILE_SIZE_PX;
+    const half = size / 2;
+    const centerX = tank.x * TILE_SIZE_PX;
+    const centerY = tank.y * TILE_SIZE_PX;
+    const color = TANK_COLORS[tank.color];
+
+    ctx.save();
+    ctx.translate(centerX, centerY);
+
+    // Ombre au sol, non tournée : elle appartient au plateau, pas au tank.
+    ctx.fillStyle = BOARD.shadow;
+    ctx.beginPath();
+    ctx.ellipse(2, 4, half * 0.95, half * 0.8, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // ── Châssis, orienté selon la direction de déplacement ──
+    //
+    // La caisse est dessinée plus longue que large — un tank se lit à sa
+    // silhouette. La hitbox, elle, reste le carré défini par `sizeTiles` :
+    // seule l'apparence est allongée, et c'est ce qui rend les passages étroits
+    // prévisibles quelle que soit l'orientation.
+    ctx.save();
+    ctx.rotate(tank.bodyAngle);
+
+    const bodyWidth = size * 0.62;
+    const halfBody = bodyWidth / 2;
+    const treadWidth = 4;
+
+    // Chenilles de part et d'autre de la caisse, avec leurs maillons.
+    ctx.fillStyle = darken(color, 0.6);
+    ctx.fillRect(-half, -halfBody - treadWidth, size, treadWidth);
+    ctx.fillRect(-half, halfBody, size, treadWidth);
+
+    ctx.fillStyle = darken(color, 0.75);
+    for (let offset = 2; offset < size - 1; offset += 4) {
+      ctx.fillRect(-half + offset, -halfBody - treadWidth, 2, treadWidth);
+      ctx.fillRect(-half + offset, halfBody, 2, treadWidth);
+    }
+
+    ctx.fillStyle = color;
+    ctx.fillRect(-half, -halfBody, size, bodyWidth);
+
+    // Reflet sur le flanc supérieur : suggère le volume sans ombrage coûteux.
+    ctx.fillStyle = lighten(color, 0.25);
+    ctx.fillRect(-half, -halfBody, size, 3);
+
+    ctx.strokeStyle = darken(color, 0.5);
+    ctx.lineWidth = 1;
+    ctx.strokeRect(-half + 0.5, -halfBody + 0.5, size - 1, bodyWidth - 1);
+    ctx.restore();
+
+    // ── Tourelle, orientée indépendamment vers la visée ──
+    ctx.save();
+    ctx.rotate(tank.turretAngle);
+
+    ctx.fillStyle = darken(color, 0.3);
+    ctx.fillRect(half * 0.35, -2.5, half * 1.15, 5);
+    ctx.strokeStyle = darken(color, 0.55);
+    ctx.strokeRect(half * 0.35 + 0.5, -2, half * 1.15 - 1, 4);
+
+    ctx.fillStyle = lighten(color, 0.1);
+    ctx.beginPath();
+    ctx.arc(0, 0, half * 0.5, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = darken(color, 0.5);
+    ctx.stroke();
+    ctx.restore();
+
+    ctx.restore();
+  }
+}

--- a/src/client/render/palette.ts
+++ b/src/client/render/palette.ts
@@ -1,0 +1,70 @@
+/**
+ * Palette du jeu.
+ *
+ * Purement présentation : rien ici n'a d'influence sur la simulation. Le
+ * parti-pris reprend celui de l'original — un plateau de jeu en bois clair,
+ * des blocs façon liège, et des tanks aux couleurs franches qui se
+ * distinguent au premier coup d'oeil sur ce fond.
+ */
+
+import type { TankColor } from '@core/state';
+
+export const BOARD = {
+  /** Sol du plateau. */
+  floor: '#c9a875',
+  /** Damier discret qui donne l'échelle sans attirer l'oeil. */
+  floorAlternate: '#c3a06d',
+  /** Ombre portée des blocs et des tanks. */
+  shadow: 'rgba(60, 40, 20, 0.28)',
+};
+
+export const BLOCKS = {
+  /** Bloc incassable : gris-brun dense. */
+  indestructibleFace: '#6d6459',
+  indestructibleTop: '#8b8175',
+  indestructibleEdge: '#4a433a',
+
+  /** Bloc cassable : liège clair, visiblement plus tendre. */
+  destructibleFace: '#b0793f',
+  destructibleTop: '#cf9557',
+  destructibleEdge: '#7d5228',
+
+  /** Trou : les tanks n'y passent pas, les obus le survolent. */
+  holeFloor: '#2a2018',
+  holeRim: '#7a6a55',
+};
+
+/** Couleur principale de chaque type de tank. */
+export const TANK_COLORS: Record<TankColor, string> = {
+  player: '#4a90d9',
+  brown: '#8b5a2b',
+  ash: '#8a8a8a',
+  teal: '#189aa0',
+  yellow: '#e8c33a',
+  pink: '#e87ab0',
+  green: '#4caf50',
+  purple: '#8e5fc0',
+  white: '#f2f2f2',
+  black: '#3a3a3a',
+};
+
+/**
+ * Assombrit une couleur hexadécimale d'un facteur donné.
+ *
+ * Sert à dériver les chenilles et les contours depuis la couleur principale,
+ * pour que chaque tank reste cohérent sans avoir à décliner la palette à la main.
+ */
+export function darken(hex: string, factor: number): string {
+  const value = Number.parseInt(hex.slice(1), 16);
+  const r = Math.round(((value >> 16) & 0xff) * (1 - factor));
+  const g = Math.round(((value >> 8) & 0xff) * (1 - factor));
+  const b = Math.round((value & 0xff) * (1 - factor));
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+/** Éclaircit une couleur hexadécimale vers le blanc. */
+export function lighten(hex: string, factor: number): string {
+  const value = Number.parseInt(hex.slice(1), 16);
+  const mix = (channel: number): number => Math.round(channel + (255 - channel) * factor);
+  return `rgb(${mix((value >> 16) & 0xff)}, ${mix((value >> 8) & 0xff)}, ${mix(value & 0xff)})`;
+}

--- a/src/client/render/snapshots.ts
+++ b/src/client/render/snapshots.ts
@@ -1,0 +1,81 @@
+/**
+ * Instantanés de rendu et interpolation.
+ *
+ * La simulation avance par pas de 1/60 s, l'écran rafraîchit à sa propre
+ * cadence. Dessiner directement le dernier état simulé produirait des saccades
+ * sur un écran 144 Hz. On interpole donc entre les deux derniers pas.
+ *
+ * On extrait un instantané léger plutôt que de cloner le monde entier à chaque
+ * pas : seules les grandeurs continues ont besoin d'être interpolées, et un
+ * `structuredClone` par tick serait du gaspillage pur.
+ *
+ * Cette même structure servira en multijoueur (#13) à interpoler les entités
+ * distantes avec un retard d'environ 100 ms.
+ */
+
+import { lerp, lerpAngle } from '@core/math';
+import type { TankColor, World } from '@core/state';
+
+export interface TankView {
+  id: number;
+  color: TankColor;
+  x: number;
+  y: number;
+  bodyAngle: number;
+  turretAngle: number;
+  alive: boolean;
+}
+
+export interface RenderSnapshot {
+  tick: number;
+  tanks: TankView[];
+}
+
+/** Extrait d'un monde ce qui est nécessaire au rendu. */
+export function captureSnapshot(world: World): RenderSnapshot {
+  return {
+    tick: world.tick,
+    tanks: world.tanks.map((tank) => ({
+      id: tank.id,
+      color: tank.color,
+      x: tank.x,
+      y: tank.y,
+      bodyAngle: tank.bodyAngle,
+      turretAngle: tank.turretAngle,
+      alive: tank.alive,
+    })),
+  };
+}
+
+/**
+ * Interpole deux instantanés successifs.
+ *
+ * Les entités absentes de `previous` — celles qui viennent d'apparaître — sont
+ * reprises telles quelles depuis `current` : les faire surgir depuis une
+ * position d'origine arbitraire produirait un glissement fantôme.
+ */
+export function interpolateSnapshots(
+  previous: RenderSnapshot,
+  current: RenderSnapshot,
+  alpha: number,
+): RenderSnapshot {
+  const previousById = new Map(previous.tanks.map((tank) => [tank.id, tank]));
+
+  return {
+    tick: current.tick,
+    tanks: current.tanks.map((tank) => {
+      const before = previousById.get(tank.id);
+      if (!before) return tank;
+
+      return {
+        ...tank,
+        x: lerp(before.x, tank.x, alpha),
+        y: lerp(before.y, tank.y, alpha),
+        // Interpolation angulaire par le chemin le plus court : sinon une
+        // tourelle passant de 179° à -179° traverserait tout le cadran.
+        bodyAngle: lerpAngle(before.bodyAngle, tank.bodyAngle, alpha),
+        turretAngle: lerpAngle(before.turretAngle, tank.turretAngle, alpha),
+      };
+    }),
+  };
+}

--- a/src/core/grid.ts
+++ b/src/core/grid.ts
@@ -1,0 +1,134 @@
+/**
+ * Requêtes de collision sur la grille du terrain.
+ *
+ * L'ancienne version bouclait sur la liste complète des murs à chaque tentative
+ * de déplacement. Ici, une boîte ne teste que les tuiles qu'elle recouvre
+ * réellement — au plus quatre pour un tank — quelle que soit la taille du
+ * niveau.
+ */
+
+import { TileKind } from './state.js';
+import type { Grid } from './state.js';
+
+/**
+ * Nature de la tuile aux coordonnées données.
+ *
+ * Hors de la grille, on répond « incassable » : le monde est clos, et cette
+ * convention évite d'avoir à tester les bornes partout ailleurs.
+ */
+export function tileAt(grid: Grid, tileX: number, tileY: number): TileKind {
+  if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) {
+    return TileKind.Indestructible;
+  }
+  return grid.tiles[tileY * grid.width + tileX] ?? TileKind.Indestructible;
+}
+
+/** Remplace la tuile aux coordonnées données. Ignore les coordonnées hors grille. */
+export function setTile(grid: Grid, tileX: number, tileY: number, kind: TileKind): void {
+  if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) return;
+  grid.tiles[tileY * grid.width + tileX] = kind;
+}
+
+/**
+ * Une tuile bloque-t-elle un tank ?
+ *
+ * Les trous bloquent les tanks mais pas les obus : c'est la seule différence
+ * entre les deux tables, et c'est ce qui justifie deux prédicats distincts
+ * plutôt qu'un booléen « solide » unique.
+ */
+export function blocksTank(kind: TileKind): boolean {
+  return kind !== TileKind.Empty;
+}
+
+/** Une tuile bloque-t-elle un obus ? Les obus survolent les trous. */
+export function blocksShell(kind: TileKind): boolean {
+  return kind === TileKind.Indestructible || kind === TileKind.Destructible;
+}
+
+/** Prédicat de solidité, pour choisir la table applicable à une entité. */
+export type SolidityTest = (kind: TileKind) => boolean;
+
+/**
+ * Une boîte alignée aux axes recouvre-t-elle une tuile solide ?
+ *
+ * La boîte est décrite par son centre et son demi-côté. Seules les tuiles
+ * effectivement touchées sont visitées.
+ */
+export function boxOverlapsSolid(
+  grid: Grid,
+  centerX: number,
+  centerY: number,
+  halfSize: number,
+  isSolid: SolidityTest,
+): boolean {
+  const minTileX = Math.floor(centerX - halfSize);
+  const maxTileX = Math.floor(centerX + halfSize);
+  const minTileY = Math.floor(centerY - halfSize);
+  const maxTileY = Math.floor(centerY + halfSize);
+
+  for (let tileY = minTileY; tileY <= maxTileY; tileY++) {
+    for (let tileX = minTileX; tileX <= maxTileX; tileX++) {
+      if (isSolid(tileAt(grid, tileX, tileY))) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Marge laissée entre une boîte et le mur contre lequel on la plaque.
+ *
+ * Sans elle, le bord de la boîte tomberait exactement sur la frontière de
+ * tuile ; `Math.floor` la rattacherait alors à la tuile solide et le tank
+ * serait considéré comme encastré au tick suivant.
+ */
+const CONTACT_EPSILON = 1e-6;
+
+/**
+ * Déplace une boîte le long d'un seul axe, en la plaquant contre le premier
+ * obstacle rencontré.
+ *
+ * ─── Pourquoi un seul axe à la fois ───────────────────────────────────────────
+ *
+ * C'est ce qui produit le *glissement le long des murs* caractéristique de
+ * Tanks! : poussé en diagonale contre un mur vertical, le tank voit son
+ * déplacement horizontal refusé mais son déplacement vertical accepté, donc il
+ * longe le mur. L'ancienne version testait le déplacement complet d'un bloc et
+ * le rejetait entièrement — le tank se collait au mur et s'arrêtait net.
+ *
+ * @returns la nouvelle coordonnée sur l'axe considéré
+ */
+export function sweepAxis(
+  grid: Grid,
+  centerX: number,
+  centerY: number,
+  halfSize: number,
+  isSolid: SolidityTest,
+  axis: 'x' | 'y',
+  delta: number,
+): number {
+  const origin = axis === 'x' ? centerX : centerY;
+  if (delta === 0) return origin;
+
+  const target = origin + delta;
+  const targetX = axis === 'x' ? target : centerX;
+  const targetY = axis === 'x' ? centerY : target;
+
+  if (!boxOverlapsSolid(grid, targetX, targetY, halfSize, isSolid)) {
+    return target;
+  }
+
+  // Bloqué : on plaque la boîte contre la face de la tuile qui l'arrête.
+  // Le pas d'un tank étant très inférieur à une tuile, il ne peut pénétrer
+  // qu'une seule rangée par pas, et cette frontière est donc la bonne.
+  const snapped =
+    delta > 0
+      ? Math.floor(target + halfSize) - halfSize - CONTACT_EPSILON
+      : Math.floor(target - halfSize) + 1 + halfSize + CONTACT_EPSILON;
+
+  // Si le calage ferait reculer la boîte — cas d'un chevauchement préexistant,
+  // par exemple après la destruction d'un mur sous un tank — on préfère ne pas
+  // bouger plutôt que de la téléporter.
+  if (delta > 0) return snapped > origin ? snapped : origin;
+  return snapped < origin ? snapped : origin;
+}

--- a/src/core/math.ts
+++ b/src/core/math.ts
@@ -1,0 +1,76 @@
+/**
+ * Utilitaires géométriques de la simulation.
+ *
+ * Tout est en unités monde : distances en tuiles, angles en radians.
+ */
+
+export const TAU = Math.PI * 2;
+
+/** Borne une valeur dans [min, max]. */
+export function clamp(value: number, min: number, max: number): number {
+  return value < min ? min : value > max ? max : value;
+}
+
+/**
+ * Ramène un angle dans (-π, π].
+ *
+ * Indispensable avant toute comparaison d'angles : sans ça, passer de 359° à 1°
+ * ressemble à un demi-tour de 358° au lieu d'un pas de 2°.
+ */
+export function normalizeAngle(angle: number): number {
+  const wrapped = angle % TAU;
+  if (wrapped > Math.PI) return wrapped - TAU;
+  if (wrapped <= -Math.PI) return wrapped + TAU;
+  return wrapped;
+}
+
+/**
+ * Fait tourner `current` vers `target` d'au plus `maxDelta` radians, par le
+ * chemin le plus court.
+ *
+ * Utilisé pour l'orientation du châssis : dans Tanks!, le tank se déplace
+ * immédiatement dans la direction demandée et son corps pivote pour rattraper.
+ * L'orientation est donc purement visuelle et ne freine jamais le déplacement.
+ */
+export function rotateToward(current: number, target: number, maxDelta: number): number {
+  const difference = normalizeAngle(target - current);
+  return normalizeAngle(current + clamp(difference, -maxDelta, maxDelta));
+}
+
+/**
+ * Normalise un vecteur de direction si sa norme dépasse 1.
+ *
+ * Les entrées clavier donnent (1, 1) en diagonale, ce qui vaut √2 ≈ 1,41 : sans
+ * normalisation, on se déplacerait 41 % plus vite en diagonale. Les entrées
+ * analogiques d'une manette, elles, sont déjà dans le disque unité et doivent
+ * être laissées telles quelles pour conserver leur dosage.
+ */
+export function limitToUnitDisc(x: number, y: number): { x: number; y: number } {
+  const lengthSquared = x * x + y * y;
+  if (lengthSquared <= 1 || lengthSquared === 0) return { x, y };
+
+  const length = Math.sqrt(lengthSquared);
+  return { x: x / length, y: y / length };
+}
+
+/** Carré de la distance entre deux points. Évite une racine carrée inutile. */
+export function distanceSquared(ax: number, ay: number, bx: number, by: number): number {
+  const dx = bx - ax;
+  const dy = by - ay;
+  return dx * dx + dy * dy;
+}
+
+/** Interpolation linéaire. */
+export function lerp(from: number, to: number, t: number): number {
+  return from + (to - from) * t;
+}
+
+/**
+ * Interpolation angulaire par le chemin le plus court.
+ *
+ * Sans elle, une tourelle qui passe de 179° à -179° traverserait tout le cadran
+ * à l'écran alors qu'elle n'a bougé que de 2°.
+ */
+export function lerpAngle(from: number, to: number, t: number): number {
+  return normalizeAngle(from + normalizeAngle(to - from) * t);
+}

--- a/src/core/systems/movement.ts
+++ b/src/core/systems/movement.ts
@@ -1,0 +1,75 @@
+/**
+ * Déplacement des tanks.
+ *
+ * Deux principes, tous deux repris du jeu original :
+ *
+ * 1. **La boîte de collision ne tourne pas.** Le châssis pivote à l'écran, mais
+ *    la hitbox reste une AABB. C'est ce qui rend les passages étroits prévisibles :
+ *    si le tank entre dans un couloir, il y entre quelle que soit son orientation.
+ *
+ * 2. **Le déplacement est résolu axe par axe.** C'est de là que vient le
+ *    glissement le long des murs, et c'est ce qui manquait à l'ancienne version.
+ */
+
+import { blocksTank, sweepAxis } from '../grid.js';
+import { limitToUnitDisc, rotateToward } from '../math.js';
+import { DT } from '../tick.js';
+import { TUNING } from '../tuning.js';
+import type { InputCommand, Tank, World } from '../state.js';
+
+/**
+ * Vitesse de déplacement d'un tank, en tuiles par seconde.
+ *
+ * Le multiplicateur par couleur arrive avec les profils d'IA (#11) ; d'ici là,
+ * tous les tanks avancent à la vitesse de référence du joueur.
+ */
+function speedOf(_tank: Tank): number {
+  return TUNING.tank.speedTilesPerSecond;
+}
+
+/** Applique l'intention d'un tick à un tank. */
+export function applyMovement(world: World, tank: Tank, input: InputCommand): void {
+  // La tourelle suit la visée sans inertie : elle est pointée, pas pilotée.
+  tank.turretAngle = input.aim;
+
+  if (!tank.alive) return;
+
+  const direction = limitToUnitDisc(input.moveX, input.moveY);
+  const isMoving = direction.x !== 0 || direction.y !== 0;
+
+  if (isMoving) {
+    // Le châssis s'oriente vers la direction demandée, mais n'a aucune
+    // influence sur le déplacement : le tank part immédiatement, le corps
+    // rattrape. C'est ce qui donne au pilotage sa réactivité.
+    tank.bodyAngle = rotateToward(
+      tank.bodyAngle,
+      Math.atan2(direction.y, direction.x),
+      TUNING.tank.turnRateRadiansPerSecond * DT,
+    );
+
+    const step = speedOf(tank) * DT;
+    const half = TUNING.tank.sizeTiles / 2;
+
+    // X d'abord, puis Y avec le X déjà résolu : c'est cet enchaînement qui
+    // produit le glissement. Tester les deux axes ensemble rejetterait le
+    // déplacement entier dès qu'un seul des deux est bloqué.
+    tank.x = sweepAxis(world.grid, tank.x, tank.y, half, blocksTank, 'x', direction.x * step);
+    tank.y = sweepAxis(world.grid, tank.x, tank.y, half, blocksTank, 'y', direction.y * step);
+  }
+}
+
+/**
+ * Fait avancer tous les tanks d'un pas.
+ *
+ * Les tanks sans intention pour ce tick — ceux de l'IA tant que #11 n'est pas
+ * là, ou un joueur dont le paquet s'est perdu — restent simplement immobiles.
+ */
+export function updateMovement(
+  world: World,
+  intents: ReadonlyMap<number, InputCommand>,
+): void {
+  for (const tank of world.tanks) {
+    const input = intents.get(tank.id);
+    if (input) applyMovement(world, tank, input);
+  }
+}

--- a/src/core/tick.ts
+++ b/src/core/tick.ts
@@ -14,6 +14,7 @@
  * dérivaient l'un de l'autre.
  */
 
+import { updateMovement } from './systems/movement.js';
 import type { InputCommand, World } from './state.js';
 
 /**
@@ -54,9 +55,13 @@ export type TickInputs = ReadonlyArray<readonly [tankId: number, input: InputCom
  * L'ordre n'est pas anodin : il fixe l'arbitrage des cas simultanés. Il est
  * figé ici, et le test de déterminisme le verrouille.
  */
-export function tick(world: World, _inputs: TickInputs): void {
-  // 1. Décisions de l'IA          → #11 (renseigne les intentions des tanks non joueurs)
-  // 2. Déplacement des tanks      → #7  (résolution X puis Y, glissement le long des murs)
+export function tick(world: World, inputs: TickInputs): void {
+  // 1. Décisions de l'IA : renseigne les intentions des tanks non joueurs → #11
+  const intents = new Map(inputs);
+
+  // 2. Déplacement des tanks : résolution X puis Y, glissement le long des murs.
+  updateMovement(world, intents);
+
   // 3. Déplacement des obus       → #8  (intégration balayée, rebonds)
   // 4. Mèches et détonations      → #9  (mines, explosions, destruction du terrain)
   // 5. Résolution des dégâts      → #8/#9 (obus↔tank, obus↔obus, explosion↔entités)

--- a/src/shared/missions/parse.ts
+++ b/src/shared/missions/parse.ts
@@ -1,0 +1,143 @@
+/**
+ * Lecture des missions écrites en grille ASCII.
+ *
+ * Le format remplace les listes de coordonnées de blocs de l'ancienne version :
+ *
+ * ```ts
+ * indestructibleWalls: [{ x: 6, y: 3 }, { x: 6, y: 4 }, { x: 12, y: 3 }, ...]
+ * ```
+ *
+ * Impossible de se représenter une arène en lisant ça, impossible de relire un
+ * diff, et les erreurs y passent inaperçues — la mission 2 déclarait un spawn
+ * joueur en `y: 23` pour une arène de 17 blocs de haut, et personne ne l'avait vu.
+ *
+ * Une grille ASCII se lit d'un coup d'oeil et se relit dans un diff.
+ *
+ * Les 20 missions et la validation complète arrivent en #12 ; ce module fournit
+ * déjà la lecture, qui est identique.
+ */
+
+import { TileKind } from '@core/state';
+import type { Grid, TankColor } from '@core/state';
+
+/** Caractère → nature de tuile. */
+const TILE_SYMBOLS: Readonly<Record<string, TileKind>> = {
+  '.': TileKind.Empty,
+  ' ': TileKind.Empty,
+  '#': TileKind.Indestructible,
+  X: TileKind.Destructible,
+  H: TileKind.Hole,
+};
+
+/** Caractère → couleur de tank ennemi. */
+const ENEMY_SYMBOLS: Readonly<Record<string, TankColor>> = {
+  b: 'brown',
+  a: 'ash',
+  t: 'teal',
+  y: 'yellow',
+  r: 'pink',
+  g: 'green',
+  p: 'purple',
+  w: 'white',
+  k: 'black',
+};
+
+/** Position au centre d'une tuile, en coordonnées monde. */
+export interface SpawnPoint {
+  x: number;
+  y: number;
+}
+
+export interface EnemySpawn extends SpawnPoint {
+  color: TankColor;
+}
+
+export interface ParsedMission {
+  grid: Grid;
+  /** Points de départ des joueurs, dans l'ordre des chiffres 1 à 4. */
+  playerSpawns: SpawnPoint[];
+  enemySpawns: EnemySpawn[];
+}
+
+/** Erreur de lecture, avec la position fautive pour rendre le diagnostic direct. */
+export class MissionParseError extends Error {
+  constructor(message: string) {
+    super(`Mission invalide : ${message}`);
+    this.name = 'MissionParseError';
+  }
+}
+
+/**
+ * Convertit une grille ASCII en terrain et points de départ.
+ *
+ * Les lignes vides en tête et en fin sont ignorées, pour que les gabarits
+ * puissent être écrits sur plusieurs lignes sans artifice.
+ */
+export function parseMission(source: string): ParsedMission {
+  const rows = source.split('\n');
+
+  while (rows.length > 0 && rows[0]!.trim() === '') rows.shift();
+  while (rows.length > 0 && rows[rows.length - 1]!.trim() === '') rows.pop();
+
+  if (rows.length === 0) throw new MissionParseError('la grille est vide');
+
+  const height = rows.length;
+  const width = rows[0]!.length;
+
+  // Une grille irrégulière décalerait silencieusement tout le terrain.
+  const ragged = rows.findIndex((row) => row.length !== width);
+  if (ragged !== -1) {
+    throw new MissionParseError(
+      `la ligne ${ragged + 1} fait ${rows[ragged]!.length} caractères au lieu de ${width}`,
+    );
+  }
+
+  const tiles: TileKind[] = new Array<TileKind>(width * height).fill(TileKind.Empty);
+  const playerSpawnsByIndex = new Map<number, SpawnPoint>();
+  const enemySpawns: EnemySpawn[] = [];
+
+  for (let y = 0; y < height; y++) {
+    const row = rows[y]!;
+
+    for (let x = 0; x < width; x++) {
+      const symbol = row[x]!;
+      // Le centre de la tuile : un tank posé sur son bord toucherait le voisin.
+      const spawn: SpawnPoint = { x: x + 0.5, y: y + 0.5 };
+
+      const tile = TILE_SYMBOLS[symbol];
+      if (tile !== undefined) {
+        tiles[y * width + x] = tile;
+        continue;
+      }
+
+      const enemyColor = ENEMY_SYMBOLS[symbol];
+      if (enemyColor) {
+        enemySpawns.push({ color: enemyColor, ...spawn });
+        continue;
+      }
+
+      if (symbol >= '1' && symbol <= '4') {
+        const index = Number(symbol);
+        if (playerSpawnsByIndex.has(index)) {
+          throw new MissionParseError(`le point de départ joueur ${index} est défini deux fois`);
+        }
+        playerSpawnsByIndex.set(index, spawn);
+        continue;
+      }
+
+      throw new MissionParseError(
+        `caractère « ${symbol} » inconnu en ligne ${y + 1}, colonne ${x + 1}`,
+      );
+    }
+  }
+
+  if (playerSpawnsByIndex.size === 0) {
+    throw new MissionParseError('aucun point de départ joueur');
+  }
+
+  const playerSpawns = [...playerSpawnsByIndex.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, spawn]) => spawn);
+
+  return { grid: { width, height, tiles }, playerSpawns, enemySpawns };
+}

--- a/tests/mission-parse.test.ts
+++ b/tests/mission-parse.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test';
+
+import { tileAt } from '../src/core/grid.js';
+import { TileKind } from '../src/core/state.js';
+import { MissionParseError, parseMission } from '../src/shared/missions/parse.js';
+
+/**
+ * Le format ASCII existe pour rendre les erreurs de level design visibles.
+ * L'ancien format (listes de `{x, y}`) laissait passer un point de départ en
+ * `y: 23` sur une arène de 17 blocs de haut sans que personne ne le remarque.
+ */
+
+describe('lecture d\'une grille', () => {
+  const SIMPLE = `
+#####
+#1.X#
+#.H.#
+#..b#
+#####
+`;
+
+  test('les dimensions se déduisent de la grille', () => {
+    const { grid } = parseMission(SIMPLE);
+    expect(grid.width).toBe(5);
+    expect(grid.height).toBe(5);
+    expect(grid.tiles).toHaveLength(25);
+  });
+
+  test('chaque symbole donne la bonne nature de tuile', () => {
+    const { grid } = parseMission(SIMPLE);
+
+    expect(tileAt(grid, 0, 0)).toBe(TileKind.Indestructible);
+    expect(tileAt(grid, 3, 1)).toBe(TileKind.Destructible);
+    expect(tileAt(grid, 2, 2)).toBe(TileKind.Hole);
+    expect(tileAt(grid, 2, 1)).toBe(TileKind.Empty);
+  });
+
+  test('les points de départ tombent au centre de leur tuile', () => {
+    const { playerSpawns } = parseMission(SIMPLE);
+
+    // Sur un bord de tuile, un tank mordrait déjà sur la tuile voisine.
+    expect(playerSpawns).toEqual([{ x: 1.5, y: 1.5 }]);
+  });
+
+  test('une case de départ est du sol libre, pas un mur', () => {
+    const { grid } = parseMission(SIMPLE);
+    expect(tileAt(grid, 1, 1)).toBe(TileKind.Empty);
+    expect(tileAt(grid, 3, 3)).toBe(TileKind.Empty);
+  });
+
+  test('les ennemis sont relevés avec leur couleur', () => {
+    const { enemySpawns } = parseMission(SIMPLE);
+    expect(enemySpawns).toEqual([{ color: 'brown', x: 3.5, y: 3.5 }]);
+  });
+
+  test('les lignes vides autour de la grille sont ignorées', () => {
+    const withPadding = parseMission('\n\n###\n#1#\n###\n\n');
+    expect(withPadding.grid.height).toBe(3);
+  });
+
+  test('les points de départ sont rendus dans l\'ordre des chiffres', () => {
+    const { playerSpawns } = parseMission(['#####', '#3.1#', '#.2.#', '#####'].join('\n'));
+
+    expect(playerSpawns).toEqual([
+      { x: 3.5, y: 1.5 },
+      { x: 2.5, y: 2.5 },
+      { x: 1.5, y: 1.5 },
+    ]);
+  });
+
+  test('les neuf couleurs d\'ennemis sont reconnues', () => {
+    const { enemySpawns } = parseMission(['###########', '#batyrgpwk#', '#....1....#', '###########'].join('\n'));
+
+    expect(enemySpawns.map((spawn) => spawn.color)).toEqual([
+      'brown',
+      'ash',
+      'teal',
+      'yellow',
+      'pink',
+      'green',
+      'purple',
+      'white',
+      'black',
+    ]);
+  });
+});
+
+describe('détection des grilles invalides', () => {
+  test('une grille irrégulière est rejetée, avec le numéro de ligne', () => {
+    // Sans ce contrôle, tout le terrain serait décalé en silence à partir de la
+    // ligne fautive.
+    expect(() => parseMission(['#####', '#1..#', '#..#', '#####'].join('\n'))).toThrow(
+      /ligne 3/,
+    );
+  });
+
+  test('un caractère inconnu est rejeté, avec sa position', () => {
+    expect(() => parseMission(['#####', '#1?.#', '#####'].join('\n'))).toThrow(
+      /« \? ».*ligne 2, colonne 3/,
+    );
+  });
+
+  test('une grille sans point de départ joueur est rejetée', () => {
+    expect(() => parseMission(['#####', '#...#', '#####'].join('\n'))).toThrow(
+      MissionParseError,
+    );
+  });
+
+  test('un point de départ dupliqué est rejeté', () => {
+    expect(() => parseMission(['#####', '#1.1#', '#####'].join('\n'))).toThrow(/deux fois/);
+  });
+
+  test('une grille vide est rejetée', () => {
+    expect(() => parseMission('   \n\n  ')).toThrow(MissionParseError);
+  });
+});

--- a/tests/movement.test.ts
+++ b/tests/movement.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from 'bun:test';
+
+import { blocksShell, blocksTank, boxOverlapsSolid, setTile, tileAt } from '../src/core/grid.js';
+import { normalizeAngle, rotateToward } from '../src/core/math.js';
+import { TileKind } from '../src/core/state.js';
+import type { InputCommand, Tank, World } from '../src/core/state.js';
+import { TICK_RATE, tick } from '../src/core/tick.js';
+import type { TickInputs } from '../src/core/tick.js';
+import { REFERENCE_MEASUREMENTS, TILE_SIZE_PX, TUNING } from '../src/core/tuning.js';
+import { allocateEntityId, createWorld } from '../src/core/world.js';
+
+/** Monde ouvert, sans obstacle intérieur, pour mesurer sans interférence. */
+function openWorld(width = 40, height = 20): World {
+  return createWorld({ width, height, seed: 1 });
+}
+
+function addTank(world: World, x: number, y: number): Tank {
+  const tank: Tank = {
+    id: allocateEntityId(world),
+    color: 'player',
+    playerId: 'p1',
+    x,
+    y,
+    bodyAngle: 0,
+    turretAngle: 0,
+    alive: true,
+    activeShells: 0,
+    activeMines: 0,
+    reloadTicks: 0,
+  };
+  world.tanks.push(tank);
+  return tank;
+}
+
+function input(overrides: Partial<InputCommand> = {}): InputCommand {
+  return { moveX: 0, moveY: 0, aim: 0, fire: false, mine: false, ...overrides };
+}
+
+/** Fait avancer le monde de `ticks` pas avec la même intention à chaque pas. */
+function run(world: World, tankId: number, command: InputCommand, ticks: number): void {
+  const inputs: TickInputs = [[tankId, command]];
+  for (let i = 0; i < ticks; i++) tick(world, inputs);
+}
+
+describe('grille', () => {
+  test('hors limites est considéré comme incassable', () => {
+    const world = openWorld(10, 10);
+    expect(tileAt(world.grid, -1, 5)).toBe(TileKind.Indestructible);
+    expect(tileAt(world.grid, 10, 5)).toBe(TileKind.Indestructible);
+    expect(tileAt(world.grid, 5, -1)).toBe(TileKind.Indestructible);
+    expect(tileAt(world.grid, 5, 10)).toBe(TileKind.Indestructible);
+  });
+
+  test('les trous arrêtent les tanks mais laissent passer les obus', () => {
+    expect(blocksTank(TileKind.Hole)).toBe(true);
+    expect(blocksShell(TileKind.Hole)).toBe(false);
+
+    // Les deux types de blocs arrêtent tout le monde.
+    for (const kind of [TileKind.Indestructible, TileKind.Destructible] as const) {
+      expect(blocksTank(kind)).toBe(true);
+      expect(blocksShell(kind)).toBe(true);
+    }
+
+    expect(blocksTank(TileKind.Empty)).toBe(false);
+    expect(blocksShell(TileKind.Empty)).toBe(false);
+  });
+
+  test('une boîte ne détecte que les tuiles qu\'elle recouvre vraiment', () => {
+    const world = openWorld(10, 10);
+    setTile(world.grid, 5, 5, TileKind.Indestructible);
+
+    const half = 0.4;
+    // Centrée sur la tuile voisine : les bords ne se touchent pas.
+    expect(boxOverlapsSolid(world.grid, 4.5, 5.5, half, blocksTank)).toBe(false);
+    // Décalée juste assez pour mordre sur la tuile solide.
+    expect(boxOverlapsSolid(world.grid, 4.95, 5.5, half, blocksTank)).toBe(true);
+  });
+});
+
+describe('vitesse de déplacement — conformité à la mesure de référence', () => {
+  test('le tank traverse l\'arène de référence dans le temps mesuré', () => {
+    // Fait observable relevé sur le jeu original : le tank du joueur parcourt
+    // 736 px en 7 s. C'est de cette mesure que dérive toute la vitesse du jeu.
+    const distanceTiles = REFERENCE_MEASUREMENTS.arenaWidthPx / TILE_SIZE_PX;
+    const expectedTicks = REFERENCE_MEASUREMENTS.tankCrossingSeconds * TICK_RATE;
+
+    const world = openWorld(Math.ceil(distanceTiles) + 8, 12);
+    const tank = addTank(world, 2, 6);
+    const startX = tank.x;
+
+    let ticks = 0;
+    const command = input({ moveX: 1 });
+    while (tank.x - startX < distanceTiles && ticks < expectedTicks * 3) {
+      run(world, tank.id, command, 1);
+      ticks++;
+    }
+
+    expect(Math.abs(ticks - expectedTicks)).toBeLessThanOrEqual(1);
+  });
+
+  test('la diagonale ne va pas plus vite que la ligne droite', () => {
+    // Sans normalisation, une entrée clavier (1, 1) donnerait √2 ≈ 1,41 fois la
+    // vitesse nominale — le bug de « strafe diagonal » classique.
+    const straight = openWorld();
+    const straightTank = addTank(straight, 5, 10);
+    run(straight, straightTank.id, input({ moveX: 1 }), 60);
+    const straightDistance = straightTank.x - 5;
+
+    const diagonal = openWorld();
+    const diagonalTank = addTank(diagonal, 5, 10);
+    run(diagonal, diagonalTank.id, input({ moveX: 1, moveY: 1 }), 60);
+    const diagonalDistance = Math.hypot(diagonalTank.x - 5, diagonalTank.y - 10);
+
+    expect(diagonalDistance).toBeCloseTo(straightDistance, 6);
+  });
+
+  test('une entrée analogique partielle conserve son dosage', () => {
+    // Une manette poussée à moitié doit avancer à moitié : on ne normalise que
+    // ce qui déborde du disque unité.
+    const world = openWorld();
+    const tank = addTank(world, 5, 10);
+    run(world, tank.id, input({ moveX: 0.5 }), 60);
+
+    const expected = (TUNING.tank.speedTilesPerSecond * 0.5 * 60) / TICK_RATE;
+    expect(tank.x - 5).toBeCloseTo(expected, 6);
+  });
+});
+
+describe('glissement le long des murs', () => {
+  test('poussé en diagonale contre un mur vertical, le tank longe le mur', () => {
+    const world = openWorld(20, 20);
+    // Mur vertical complet en x = 8.
+    for (let y = 1; y < 19; y++) setTile(world.grid, 8, y, TileKind.Indestructible);
+
+    const tank = addTank(world, 7.4, 10);
+    const startY = tank.y;
+
+    run(world, tank.id, input({ moveX: 1, moveY: 1 }), 30);
+
+    // L'axe bloqué n'avance pas...
+    expect(tank.x).toBeLessThan(8);
+    // ...mais l'axe libre, si. C'est tout l'objet de la résolution axe par axe :
+    // l'ancienne version rejetait le déplacement entier et le tank se figeait.
+    expect(tank.y).toBeGreaterThan(startY + 0.5);
+  });
+
+  test('poussé en diagonale contre un mur horizontal, le tank longe le mur', () => {
+    const world = openWorld(20, 20);
+    for (let x = 1; x < 19; x++) setTile(world.grid, x, 8, TileKind.Indestructible);
+
+    const tank = addTank(world, 10, 7.4);
+    const startX = tank.x;
+
+    run(world, tank.id, input({ moveX: 1, moveY: 1 }), 30);
+
+    expect(tank.y).toBeLessThan(8);
+    expect(tank.x).toBeGreaterThan(startX + 0.5);
+  });
+
+  test('un coin rentrant arrête les deux axes', () => {
+    const world = openWorld(20, 20);
+    for (let y = 1; y < 19; y++) setTile(world.grid, 8, y, TileKind.Indestructible);
+    for (let x = 1; x < 19; x++) setTile(world.grid, x, 8, TileKind.Indestructible);
+
+    const tank = addTank(world, 7.4, 7.4);
+    run(world, tank.id, input({ moveX: 1, moveY: 1 }), 60);
+
+    expect(tank.x).toBeLessThan(8);
+    expect(tank.y).toBeLessThan(8);
+  });
+
+  test('le tank se plaque contre le mur, sans laisser d\'interstice', () => {
+    const world = openWorld(20, 20);
+    for (let y = 1; y < 19; y++) setTile(world.grid, 8, y, TileKind.Indestructible);
+
+    const tank = addTank(world, 5, 10);
+    run(world, tank.id, input({ moveX: 1 }), 200);
+
+    // Rejeter simplement le pas laisserait un jeu pouvant atteindre une frame
+    // de déplacement ; on cale donc la boîte contre la face de la tuile.
+    const expectedX = 8 - TUNING.tank.sizeTiles / 2;
+    expect(tank.x).toBeCloseTo(expectedX, 4);
+  });
+});
+
+describe('étanchéité des murs', () => {
+  test('aucune direction ne permet de traverser la bordure', () => {
+    // Balayage sur 360 directions : un seul angle qui passe suffirait à rendre
+    // le jeu injouable, et ce genre de trou est indétectable à la main.
+    const escapes: number[] = [];
+
+    for (let degrees = 0; degrees < 360; degrees++) {
+      const radians = (degrees * Math.PI) / 180;
+      const world = openWorld(12, 12);
+      const tank = addTank(world, 6, 6);
+
+      run(world, tank.id, input({ moveX: Math.cos(radians), moveY: Math.sin(radians) }), 600);
+
+      const half = TUNING.tank.sizeTiles / 2;
+      const inside =
+        tank.x - half >= 1 - 1e-3 &&
+        tank.y - half >= 1 - 1e-3 &&
+        tank.x + half <= 11 + 1e-3 &&
+        tank.y + half <= 11 + 1e-3;
+
+      if (!inside) escapes.push(degrees);
+    }
+
+    expect(escapes).toEqual([]);
+  });
+
+  test('un tank ne peut pas entrer sur un trou', () => {
+    const world = openWorld(20, 20);
+    for (let y = 1; y < 19; y++) setTile(world.grid, 8, y, TileKind.Hole);
+
+    const tank = addTank(world, 5, 10);
+    run(world, tank.id, input({ moveX: 1 }), 200);
+
+    expect(tank.x).toBeLessThan(8);
+  });
+});
+
+describe('orientation', () => {
+  test('la tourelle suit la visée sans inertie', () => {
+    const world = openWorld();
+    const tank = addTank(world, 5, 5);
+
+    run(world, tank.id, input({ aim: 1.234 }), 1);
+    expect(tank.turretAngle).toBeCloseTo(1.234, 9);
+  });
+
+  test('le châssis pivote progressivement, sans freiner le déplacement', () => {
+    const world = openWorld();
+    const tank = addTank(world, 5, 10);
+    tank.bodyAngle = Math.PI; // orienté à l'opposé de la direction demandée
+
+    // Un seul pas : le corps n'a pas eu le temps de se retourner...
+    run(world, tank.id, input({ moveX: 1 }), 1);
+    expect(Math.abs(normalizeAngle(tank.bodyAngle))).toBeGreaterThan(0.1);
+
+    // ...et pourtant le tank a déjà avancé à pleine vitesse. Dans Tanks!, on
+    // part immédiatement dans la direction demandée ; le corps rattrape.
+    expect(tank.x).toBeCloseTo(5 + TUNING.tank.speedTilesPerSecond / TICK_RATE, 6);
+  });
+
+  test('le châssis finit par s\'aligner sur la direction du déplacement', () => {
+    const world = openWorld();
+    const tank = addTank(world, 5, 10);
+    tank.bodyAngle = Math.PI;
+
+    run(world, tank.id, input({ moveX: 1 }), 60);
+    expect(Math.abs(normalizeAngle(tank.bodyAngle))).toBeLessThan(1e-6);
+  });
+
+  test('rotateToward passe par le chemin le plus court', () => {
+    // De 175° vers -175° : 10° dans le sens positif, pas 350° dans l'autre.
+    const from = (175 * Math.PI) / 180;
+    const to = (-175 * Math.PI) / 180;
+    const stepped = rotateToward(from, to, (2 * Math.PI) / 180);
+
+    expect(normalizeAngle(stepped - from)).toBeCloseTo((2 * Math.PI) / 180, 9);
+  });
+
+  test('un tank mort ne bouge plus mais garde une tourelle lisible', () => {
+    const world = openWorld();
+    const tank = addTank(world, 5, 10);
+    tank.alive = false;
+
+    run(world, tank.id, input({ moveX: 1, aim: 0.5 }), 60);
+
+    expect(tank.x).toBe(5);
+    expect(tank.turretAngle).toBeCloseTo(0.5, 9);
+  });
+});
+
+describe('déterminisme du mouvement', () => {
+  test('deux mondes recevant les mêmes intentions restent identiques', () => {
+    const build = (): { world: World; id: number } => {
+      const world = openWorld(20, 20);
+      for (let y = 1; y < 19; y++) setTile(world.grid, 8, y, TileKind.Indestructible);
+      const tank = addTank(world, 5, 10);
+      return { world, id: tank.id };
+    };
+
+    const a = build();
+    const b = build();
+
+    // Suite d'intentions variée mais reproductible.
+    for (let i = 0; i < 600; i++) {
+      const command = input({
+        moveX: Math.cos(i / 17),
+        moveY: Math.sin(i / 23),
+        aim: i / 11,
+      });
+      run(a.world, a.id, command, 1);
+      run(b.world, b.id, command, 1);
+    }
+
+    expect(a.world.tanks[0]).toEqual(b.world.tanks[0]!);
+  });
+});

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test';
+
+import { normalizeAngle } from '../src/core/math.js';
+import { captureSnapshot, interpolateSnapshots } from '../src/client/render/snapshots.js';
+import type { RenderSnapshot } from '../src/client/render/snapshots.js';
+import type { World } from '../src/core/state.js';
+import { allocateEntityId, createWorld } from '../src/core/world.js';
+
+/**
+ * L'interpolation existe parce que la simulation avance à 60 Hz alors que
+ * l'écran peut rafraîchir à 144 : dessiner directement le dernier état simulé
+ * produirait des saccades visibles.
+ */
+
+function worldWithTank(x: number, y: number, angles = { body: 0, turret: 0 }): World {
+  const world = createWorld({ width: 10, height: 10, seed: 1 });
+  world.tanks.push({
+    id: allocateEntityId(world),
+    color: 'player',
+    playerId: 'p1',
+    x,
+    y,
+    bodyAngle: angles.body,
+    turretAngle: angles.turret,
+    alive: true,
+    activeShells: 0,
+    activeMines: 0,
+    reloadTicks: 0,
+  });
+  return world;
+}
+
+describe('capture', () => {
+  test("l'instantané ne retient que ce qui sert au rendu", () => {
+    const snapshot = captureSnapshot(worldWithTank(2, 3));
+    const tank = snapshot.tanks[0]!;
+
+    expect(Object.keys(tank).sort()).toEqual([
+      'alive',
+      'bodyAngle',
+      'color',
+      'id',
+      'turretAngle',
+      'x',
+      'y',
+    ]);
+  });
+
+  test("l'instantané est détaché du monde", () => {
+    // Sinon le rendu observerait l'état en cours de modification, et
+    // l'interpolation comparerait un état à lui-même.
+    const world = worldWithTank(2, 3);
+    const snapshot = captureSnapshot(world);
+
+    world.tanks[0]!.x = 99;
+    expect(snapshot.tanks[0]!.x).toBe(2);
+  });
+});
+
+describe('interpolation', () => {
+  const previous = captureSnapshot(worldWithTank(0, 0));
+  const current = captureSnapshot(worldWithTank(4, 8));
+
+  test('alpha 0 rend l\'état précédent, alpha 1 le courant', () => {
+    expect(interpolateSnapshots(previous, current, 0).tanks[0]!.x).toBeCloseTo(0, 9);
+    expect(interpolateSnapshots(previous, current, 1).tanks[0]!.x).toBeCloseTo(4, 9);
+  });
+
+  test('alpha intermédiaire place le tank entre les deux', () => {
+    const view = interpolateSnapshots(previous, current, 0.25).tanks[0]!;
+    expect(view.x).toBeCloseTo(1, 9);
+    expect(view.y).toBeCloseTo(2, 9);
+  });
+
+  test('les angles passent par le chemin le plus court', () => {
+    // De 179° à -179° : 2° de rotation, pas 358°. Sans ça, la tourelle
+    // traverserait tout le cadran à l'écran sur un simple franchissement.
+    const from = captureSnapshot(worldWithTank(0, 0, { body: 0, turret: (179 * Math.PI) / 180 }));
+    const to = captureSnapshot(worldWithTank(0, 0, { body: 0, turret: (-179 * Math.PI) / 180 }));
+
+    const midway = interpolateSnapshots(from, to, 0.5).tanks[0]!.turretAngle;
+
+    // Le milieu du chemin court est à 180°, soit ±π une fois normalisé.
+    expect(Math.abs(normalizeAngle(midway))).toBeCloseTo(Math.PI, 6);
+  });
+
+  test('une entité qui vient d\'apparaître est prise telle quelle', () => {
+    // La faire glisser depuis une position d'origine inventée produirait un
+    // fantôme traversant l'écran au moment du spawn.
+    const empty: RenderSnapshot = { tick: 0, tanks: [] };
+    const view = interpolateSnapshots(empty, current, 0.5).tanks[0]!;
+
+    expect(view.x).toBe(4);
+    expect(view.y).toBe(8);
+  });
+
+  test('l\'instantané courant n\'est pas modifié par l\'interpolation', () => {
+    interpolateSnapshots(previous, current, 0.5);
+    expect(current.tanks[0]!.x).toBe(4);
+  });
+});


### PR DESCRIPTION
Closes #7

Le jeu redevient jouable : on pilote un tank dans un labyrinthe, la tourelle suit la souris.

## Collisions par grille

L'ancienne version bouclait sur **la liste complète des murs** à chaque tentative de déplacement (`Tank.canMoveTo`). Une boîte ne teste désormais que les tuiles qu'elle recouvre — au plus quatre pour un tank — quelle que soit la taille du niveau. Le tableau `walls` exporté en global et muté en place disparaît avec.

Deux prédicats de solidité distincts plutôt qu'un booléen unique : les trous bloquent les tanks mais **pas** les obus, qui les survoleront (#8).

## Le glissement le long des murs

C'est le point de fidélité de cette étape, et il vient de la **résolution axe par axe** : X d'abord, puis Y avec le X déjà résolu.

Poussé en diagonale contre un mur vertical, le tank voit son déplacement horizontal refusé mais son déplacement vertical accepté — donc il longe le mur. L'ancienne version testait le déplacement complet d'un bloc et le rejetait entièrement : le tank se figeait contre le mur.

La boîte est **plaquée contre la face de la tuile** qui l'arrête, pas simplement laissée où elle était : rejeter le pas laisserait un interstice pouvant atteindre une frame de déplacement. Le calage est ignoré s'il ferait *reculer* la boîte — cas d'un chevauchement préexistant, par exemple après la destruction d'un mur sous un tank (#9).

## Hitbox et orientation

La hitbox est une **AABB qui ne tourne pas**. Le châssis pivote à l'écran, mais un couloir franchissable le reste quelle que soit l'orientation — c'est ce qui rend les passages étroits prévisibles, comme dans l'original.

Le corps s'oriente progressivement vers la direction demandée **sans jamais freiner le déplacement** : dans Tanks!, on part immédiatement dans la direction du stick et le corps rattrape. Un test vérifie précisément ça — après un seul pas, le corps n'a pas eu le temps de se retourner et le tank a pourtant déjà avancé à pleine vitesse.

Les entrées diagonales sont ramenées dans le disque unité : sans ça, `(1, 1)` au clavier donnerait √2 ≈ 1,41 fois la vitesse nominale. Les entrées analogiques partielles, elles, conservent leur dosage.

## Rendu isolé

Le rendu est derrière l'interface `Renderer` et **ne lit jamais le `World`** : il reçoit un `RenderSnapshot` déjà interpolé. Il ne peut donc pas, même par accident, modifier l'état simulé — et un renderer 3D pourra être branché plus tard sans toucher au gameplay.

L'interpolation entre les deux derniers pas évite les saccades sur écran haute fréquence. Les angles sont interpolés par le chemin le plus court : sans ça, une tourelle passant de 179° à −179° traverserait tout le cadran alors qu'elle n'a bougé que de 2°.

Le terrain est mis en cache dans un canevas hors écran et reconstruit seulement sur invalidation — il ne change qu'à la destruction d'un bloc, alors que le reste est redessiné jusqu'à 240 fois par seconde.

## Missions en grille ASCII

Les listes de coordonnées de l'ancienne version étaient illisibles :

```ts
indestructibleWalls: [{ x: 6, y: 3 }, { x: 6, y: 4 }, { x: 12, y: 3 }, ...]
```

Impossible de se représenter une arène, impossible de relire un diff — et les erreurs y passaient inaperçues : **la mission 2 déclarait `playerSpawn: { x: 3, y: 23 }` pour une arène de 17 blocs de haut**.

Le parseur rejette grilles irrégulières, caractères inconnus, spawns dupliqués et grilles sans joueur, en indiquant à chaque fois la ligne et la colonne fautives. Les 20 missions sont portées en #12.

## Vérification

| Commande | Résultat |
|---|---|
| `bun test ./tests` | **76 passés**, 0 échec |
| `bunx tsc --noEmit` | aucune erreur |
| `bunx playwright test` | **6 passés** |

Deux tests méritent d'être signalés :

- **Conformité de vitesse** : le tank traverse 736 px en **7,00 s ± 1 tick**, exactement la mesure relevée sur l'original et documentée dans `legacy/src/constants.ts`. C'est la première fois que cette valeur est vérifiable, le pas de temps fixe (#6) l'ayant rendue mesurable.
- **Étanchéité** : balayage sur **360 directions** à vitesse maximale, aucune traversée de mur. Un seul angle qui passerait rendrait le jeu injouable, et ce genre de trou est indétectable à la main.

Les tests bout-en-bout couvrent la chaîne complète clavier → souris → simulation → rendu, dont le glissement contre un mur et le relâchement des touches à la perte de focus (sans quoi un tank filerait indéfiniment après un changement d'onglet).

## Capture

Le bac à sable réunit volontairement les situations qui mettent le mouvement en défaut : couloirs d'une tuile, angles rentrants, culs-de-sac, blocs cassables et un puits de trous à contourner.

Rendu : sol de plateau en bois, blocs incassables gris en relief, blocs cassables couleur liège avec grain visible — le joueur doit pouvoir décider d'un coup d'oeil où poser une mine —, trous sombres, tank joueur bleu avec chenilles et tourelle indépendante.
