### PR TITLE
Physique des obus : balayage continu, rebonds fidèles et quotas

### DIFF
--- a/e2e/shells.spec.ts
+++ b/e2e/shells.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from '@playwright/test';
+
+// La déclaration de `window.__tanks` vit dans src/client/debug-bridge.ts.
+import '../src/client/debug-bridge';
+
+type Page = import('@playwright/test').Page;
+
+/** Lit l'état des obus en vol. */
+async function shells(page: Page) {
+  return page.evaluate(() =>
+    (window.__tanks?.world.shells ?? []).map((shell) => ({
+      x: shell.x,
+      y: shell.y,
+      vx: shell.vx,
+      vy: shell.vy,
+      bouncesLeft: shell.bouncesLeft,
+    })),
+  );
+}
+
+/** Vise un point du canevas exprimé en fraction de sa taille. */
+async function aimAt(page: Page, fractionX: number, fractionY: number): Promise<void> {
+  const box = await page.locator('#game').boundingBox();
+  if (!box) throw new Error('canevas introuvable');
+  await page.mouse.move(box.x + box.width * fractionX, box.y + box.height * fractionY);
+  await page.waitForTimeout(80);
+}
+
+test('le clic tire un obus, qui se déplace', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  expect(await shells(page)).toHaveLength(0);
+
+  await aimAt(page, 0.05, 0.05);
+  await page.mouse.down();
+  await page.waitForTimeout(50);
+  await page.mouse.up();
+  await page.waitForTimeout(60);
+
+  const fired = await shells(page);
+  expect(fired.length).toBeGreaterThan(0);
+
+  const first = fired[0]!;
+  expect(Math.hypot(first.vx, first.vy)).toBeGreaterThan(0);
+
+  await page.waitForTimeout(150);
+  const later = await shells(page);
+
+  // L'obus a bougé — ou déjà disparu contre un mur, ce qui reste concluant.
+  if (later.length > 0) {
+    expect(later[0]!.x !== first.x || later[0]!.y !== first.y).toBe(true);
+  }
+});
+
+test('le quota d\'obus simultanés est respecté', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  // Lu depuis la table de réglages vivante plutôt que recopié : le panneau de
+  // calibration (#10) pourra changer cette valeur sans casser le test.
+  const maxShells = await page.evaluate(() => window.__tanks!.tuning.tank.maxActiveShells);
+
+  // Tir soutenu dans le couloir vertical, le plus long trajet disponible.
+  await aimAt(page, 0.96, 0.02);
+  await page.mouse.down();
+  await page.waitForTimeout(1600);
+  await page.mouse.up();
+
+  const inFlight = await shells(page);
+  expect(inFlight.length).toBeLessThanOrEqual(maxShells);
+});
+
+test('un obus ricoche au lieu de traverser le mur', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  // Visée strictement verticale, calculée depuis la position réelle du tank.
+  //
+  // Viser « en bas à droite » à vue de nez ferait dériver l'obus vers la paroi
+  // latérale : le couloir ne fait qu'une tuile de large, les deux murs seraient
+  // touchés à une frame d'intervalle, et la fenêtre pendant laquelle le rebond
+  // est observable durerait un seul pas de simulation.
+  const box = await page.locator('#game').boundingBox();
+  if (!box) throw new Error('canevas introuvable');
+
+  const tankX = await page.evaluate(() => window.__tanks!.world.tanks[0]!.x);
+  const scale = box.width / (await page.evaluate(() => window.__tanks!.world.grid.width));
+
+  await page.mouse.move(box.x + tankX * scale, box.y + box.height - 2);
+  await page.waitForTimeout(80);
+
+  await page.mouse.down();
+  await page.waitForTimeout(50);
+  await page.mouse.up();
+
+  const initial = await shells(page);
+  expect(initial.length).toBeGreaterThan(0);
+  expect(initial[0]!.bouncesLeft).toBe(1);
+  expect(initial[0]!.vy).toBeGreaterThan(0);
+
+  // L'observation se fait **dans la page**, une fois par frame : dans un
+  // couloir d'une tuile de large, l'obus vit moins d'une seconde et un sondage
+  // depuis Node manquerait l'instant du rebond à cause des allers-retours.
+  //
+  // On ne présume pas non plus *quel* mur est touché en premier : la visée à la
+  // souris n'est jamais parfaitement verticale, donc le rebond peut venir d'une
+  // paroi latérale aussi bien que du fond.
+  const observation = await page.evaluate(async () => {
+    const startMs = performance.now();
+    let sawBounce = false;
+    let escaped = false;
+
+    while (performance.now() - startMs < 2500) {
+      const world = window.__tanks!.world;
+
+      for (const shell of world.shells) {
+        if (shell.bouncesLeft < 1) sawBounce = true;
+        if (
+          shell.x < 1 ||
+          shell.y < 1 ||
+          shell.x > world.grid.width - 1 ||
+          shell.y > world.grid.height - 1
+        ) {
+          escaped = true;
+        }
+      }
+
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    }
+
+    return { sawBounce, escaped };
+  });
+
+  // Ce qui ne doit jamais arriver, quel que soit le mur touché.
+  expect(observation.escaped).toBe(false);
+  expect(observation.sawBounce).toBe(true);
+});

--- a/src/client/debug-bridge.ts
+++ b/src/client/debug-bridge.ts
@@ -12,6 +12,7 @@
  */
 
 import type { World } from '@core/state';
+import type { Tuning } from '@core/tuning';
 
 /** Cadences mesurées, pour vérifier que la simulation reste indépendante de l'écran. */
 export interface RateProbe {
@@ -25,6 +26,11 @@ export interface RateProbe {
 export interface TanksDebugBridge {
   world: World;
   rates: RateProbe;
+  /**
+   * Table de réglages vivante. Les tests s'y réfèrent plutôt que de recopier
+   * des valeurs, et le panneau de calibration (#10) l'éditera en place.
+   */
+  tuning: Tuning;
 }
 
 declare global {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -9,6 +9,7 @@
  */
 
 import { TICK_RATE } from '@core/tick';
+import { TUNING } from '@core/tuning';
 import { exposeDebugBridge } from './debug-bridge';
 import type { RateProbe } from './debug-bridge';
 import { InputSampler } from './input/sampler';
@@ -65,9 +66,13 @@ function sampleRates(nowMs: number): void {
 }
 
 function drawOverlay(ctx: CanvasRenderingContext2D): void {
+  const tank = game.playerTank;
+  const shells = tank ? `${tank.activeShells}/${TUNING.tank.maxActiveShells}` : '—';
+
   const lines = [
     `pas/s ${rates.ticksPerSecond} (attendu ${TICK_RATE})   frames/s ${rates.framesPerSecond}`,
-    'ZQSD ou WASD ou flèches — souris pour viser',
+    `obus en vol ${shells}`,
+    'ZQSD / WASD / flèches — souris pour viser, clic pour tirer',
   ];
 
   // En bas de l'image : le bandeau ne doit pas masquer le terrain de jeu.
@@ -109,4 +114,4 @@ startGameLoop({
   },
 });
 
-exposeDebugBridge({ world, rates });
+exposeDebugBridge({ world, rates, tuning: TUNING });

--- a/src/client/render/canvas2d/Canvas2DRenderer.ts
+++ b/src/client/render/canvas2d/Canvas2DRenderer.ts
@@ -10,9 +10,9 @@ import { TileKind } from '@core/state';
 import type { Grid } from '@core/state';
 import { TILE_SIZE_PX, TUNING } from '@core/tuning';
 import { tileAt } from '@core/grid';
-import { BLOCKS, BOARD, TANK_COLORS, darken, lighten } from '../palette';
+import { BLOCKS, BOARD, SHELL, TANK_COLORS, darken, lighten } from '../palette';
 import type { Renderer } from '../Renderer';
-import type { RenderSnapshot, TankView } from '../snapshots';
+import type { RenderSnapshot, ShellView, TankView } from '../snapshots';
 
 /** Décalage vertical des faces de blocs, qui simule leur épaisseur. */
 const BLOCK_RELIEF_PX = 5;
@@ -63,6 +63,11 @@ export class Canvas2DRenderer implements Renderer {
 
     for (const tank of view.tanks) {
       if (tank.alive) this.#drawTank(tank);
+    }
+
+    // Les obus par-dessus les tanks : c'est ce qu'on doit suivre des yeux.
+    for (const shell of view.shells) {
+      this.#drawShell(shell);
     }
   }
 
@@ -233,6 +238,48 @@ export class Canvas2DRenderer implements Renderer {
     ctx.strokeStyle = darken(color, 0.5);
     ctx.stroke();
     ctx.restore();
+
+    ctx.restore();
+  }
+
+  /* ── Obus ────────────────────────────────────────────────────────────── */
+
+  #drawShell(shell: ShellView): void {
+    const ctx = this.#ctx;
+    const radius = TUNING.shell.radiusTiles * TILE_SIZE_PX;
+    const x = shell.x * TILE_SIZE_PX;
+    const y = shell.y * TILE_SIZE_PX;
+
+    ctx.save();
+    ctx.translate(x, y);
+
+    ctx.fillStyle = BOARD.shadow;
+    ctx.beginPath();
+    ctx.arc(1.5, 2.5, radius, 0, Math.PI * 2);
+    ctx.fill();
+
+    if (shell.kind === 'fast') {
+      // Le missile est allongé dans son axe : à deux fois la vitesse d'un obus
+      // normal, sa forme doit trahir sa nature avant qu'il n'arrive.
+      ctx.rotate(shell.heading);
+      ctx.fillStyle = SHELL.fastBody;
+      ctx.beginPath();
+      ctx.ellipse(0, 0, radius * 2.1, radius, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = SHELL.fastTip;
+      ctx.beginPath();
+      ctx.arc(radius * 1.1, 0, radius * 0.7, 0, Math.PI * 2);
+      ctx.fill();
+    } else {
+      ctx.fillStyle = SHELL.normalBody;
+      ctx.beginPath();
+      ctx.arc(0, 0, radius * 1.35, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = SHELL.normalHighlight;
+      ctx.beginPath();
+      ctx.arc(-radius * 0.35, -radius * 0.35, radius * 0.55, 0, Math.PI * 2);
+      ctx.fill();
+    }
 
     ctx.restore();
   }

--- a/src/client/render/palette.ts
+++ b/src/client/render/palette.ts
@@ -34,6 +34,20 @@ export const BLOCKS = {
   holeRim: '#7a6a55',
 };
 
+/**
+ * Obus.
+ *
+ * Volontairement neutres et non teintés par le tireur : sur un plateau où six
+ * tanks tirent en même temps, ce qui compte est de repérer un projectile, pas
+ * de savoir d'où il vient. Le missile se distingue par sa forme.
+ */
+export const SHELL = {
+  normalBody: '#3b3630',
+  normalHighlight: '#9c948a',
+  fastBody: '#d9d2c4',
+  fastTip: '#e8623a',
+};
+
 /** Couleur principale de chaque type de tank. */
 export const TANK_COLORS: Record<TankColor, string> = {
   player: '#4a90d9',

--- a/src/client/render/snapshots.ts
+++ b/src/client/render/snapshots.ts
@@ -14,7 +14,7 @@
  */
 
 import { lerp, lerpAngle } from '@core/math';
-import type { TankColor, World } from '@core/state';
+import type { ShellKind, TankColor, World } from '@core/state';
 
 export interface TankView {
   id: number;
@@ -26,9 +26,19 @@ export interface TankView {
   alive: boolean;
 }
 
+export interface ShellView {
+  id: number;
+  kind: ShellKind;
+  x: number;
+  y: number;
+  /** Orientation du déplacement, pour dessiner un missile dans son axe. */
+  heading: number;
+}
+
 export interface RenderSnapshot {
   tick: number;
   tanks: TankView[];
+  shells: ShellView[];
 }
 
 /** Extrait d'un monde ce qui est nécessaire au rendu. */
@@ -43,6 +53,13 @@ export function captureSnapshot(world: World): RenderSnapshot {
       bodyAngle: tank.bodyAngle,
       turretAngle: tank.turretAngle,
       alive: tank.alive,
+    })),
+    shells: world.shells.map((shell) => ({
+      id: shell.id,
+      kind: shell.kind,
+      x: shell.x,
+      y: shell.y,
+      heading: Math.atan2(shell.vy, shell.vx),
     })),
   };
 }
@@ -59,12 +76,14 @@ export function interpolateSnapshots(
   current: RenderSnapshot,
   alpha: number,
 ): RenderSnapshot {
-  const previousById = new Map(previous.tanks.map((tank) => [tank.id, tank]));
+  const tanksById = new Map(previous.tanks.map((tank) => [tank.id, tank]));
+  const shellsById = new Map(previous.shells.map((shell) => [shell.id, shell]));
 
   return {
     tick: current.tick,
+
     tanks: current.tanks.map((tank) => {
-      const before = previousById.get(tank.id);
+      const before = tanksById.get(tank.id);
       if (!before) return tank;
 
       return {
@@ -75,6 +94,18 @@ export function interpolateSnapshots(
         // tourelle passant de 179° à -179° traverserait tout le cadran.
         bodyAngle: lerpAngle(before.bodyAngle, tank.bodyAngle, alpha),
         turretAngle: lerpAngle(before.turretAngle, tank.turretAngle, alpha),
+      };
+    }),
+
+    shells: current.shells.map((shell) => {
+      const before = shellsById.get(shell.id);
+      if (!before) return shell;
+
+      return {
+        ...shell,
+        x: lerp(before.x, shell.x, alpha),
+        y: lerp(before.y, shell.y, alpha),
+        heading: lerpAngle(before.heading, shell.heading, alpha),
       };
     }),
   };

--- a/src/core/grid.ts
+++ b/src/core/grid.ts
@@ -132,3 +132,201 @@ export function sweepAxis(
   if (delta > 0) return snapped > origin ? snapped : origin;
   return snapped < origin ? snapped : origin;
 }
+
+/* ── Balayage continu ─────────────────────────────────────────────────────── */
+
+/** Impact trouvé par un balayage continu. */
+export interface SweepHit {
+  /** Fraction du déplacement parcourue avant l'impact, dans [0, 1]. */
+  time: number;
+  /** Normale de la face touchée : -1, 0 ou 1 sur chaque axe. */
+  normalX: number;
+  normalY: number;
+}
+
+/**
+ * Deux impacts séparés de moins que cette fraction sont considérés simultanés.
+ *
+ * C'est ce qui permet de détecter un coin : deux tuiles perpendiculaires
+ * touchées au même instant doivent réfléchir **les deux** axes. Les traiter
+ * l'une après l'autre renverrait l'obus d'où il vient.
+ */
+const SIMULTANEOUS_HIT_TOLERANCE = 1e-9;
+
+/**
+ * Instant d'entrée d'une boîte mobile dans une tuile, par la méthode des
+ * tranches (« slab method »).
+ *
+ * La tuile est dilatée du demi-côté de la boîte, ce qui ramène le problème au
+ * déplacement d'un point — c'est la construction de Minkowski.
+ *
+ * ─── Arêtes internes ─────────────────────────────────────────────────────────
+ *
+ * Une face n'est une vraie surface de collision que si la tuile située de
+ * l'autre côté est franchissable. Le long d'un mur plat, la face gauche de
+ * chaque tuile est enfouie dans la tuile précédente : elle n'existe pas
+ * physiquement.
+ *
+ * Sans ce masquage, un obus tiré à 45° contre un mur plat atteint la face
+ * supérieure de la tuile et la face gauche de sa voisine **au même instant**.
+ * Les deux normales se cumulent, l'obus repart d'où il vient au lieu de
+ * ricocher. C'est le piège classique des grilles de tuiles, et il ne se
+ * manifeste qu'aux angles où les deux entrées coïncident — typiquement 45°.
+ *
+ * @returns l'instant d'entrée et l'entrée par axe, ou `null` s'il n'y a pas
+ *          d'impact dans ce pas
+ */
+function sweepAgainstTile(
+  grid: Grid,
+  isSolid: SolidityTest,
+  centerX: number,
+  centerY: number,
+  halfSize: number,
+  dx: number,
+  dy: number,
+  tileX: number,
+  tileY: number,
+): { time: number; entryX: number; entryY: number } | null {
+  const minX = tileX - halfSize;
+  const maxX = tileX + 1 + halfSize;
+  const minY = tileY - halfSize;
+  const maxY = tileY + 1 + halfSize;
+
+  let entryX: number;
+  let exitX: number;
+  if (dx === 0) {
+    // Aucun déplacement sur cet axe : soit on est déjà dans la tranche pour
+    // toujours, soit on n'y entrera jamais.
+    if (centerX <= minX || centerX >= maxX) return null;
+    entryX = Number.NEGATIVE_INFINITY;
+    exitX = Number.POSITIVE_INFINITY;
+  } else {
+    const first = (minX - centerX) / dx;
+    const second = (maxX - centerX) / dx;
+    entryX = Math.min(first, second);
+    exitX = Math.max(first, second);
+
+    // La face abordée sur cet axe est-elle une vraie surface ?
+    const neighbour = dx > 0 ? tileX - 1 : tileX + 1;
+    if (isSolid(tileAt(grid, neighbour, tileY))) {
+      entryX = Number.NEGATIVE_INFINITY;
+    }
+  }
+
+  let entryY: number;
+  let exitY: number;
+  if (dy === 0) {
+    if (centerY <= minY || centerY >= maxY) return null;
+    entryY = Number.NEGATIVE_INFINITY;
+    exitY = Number.POSITIVE_INFINITY;
+  } else {
+    const first = (minY - centerY) / dy;
+    const second = (maxY - centerY) / dy;
+    entryY = Math.min(first, second);
+    exitY = Math.max(first, second);
+
+    const neighbour = dy > 0 ? tileY - 1 : tileY + 1;
+    if (isSolid(tileAt(grid, tileX, neighbour))) {
+      entryY = Number.NEGATIVE_INFINITY;
+    }
+  }
+
+  const entry = Math.max(entryX, entryY);
+  const exit = Math.min(exitX, exitY);
+
+  // Les tranches ne se recouvrent pas, ou l'impact est hors du pas courant.
+  if (entry > exit || exit <= 0 || entry > 1) return null;
+
+  // Entrée à l'infini négatif : toutes les faces abordées sont internes, la
+  // tuile est enfouie dans le mur et ne peut rien arrêter.
+  // Entrée négative finie : chevauchement préexistant, l'appelant s'en occupe
+  // (un obus né dans un mur est détruit plutôt que réfléchi au hasard).
+  if (entry < 0) return null;
+
+  return { time: entry, entryX, entryY };
+}
+
+/**
+ * Trouve le **premier** obstacle rencontré par une boîte au cours d'un
+ * déplacement, et la normale de la face touchée.
+ *
+ * ─── Pourquoi un balayage plutôt qu'un test après coup ───────────────────────
+ *
+ * L'ancienne version déplaçait l'obus (`this.x += this.dx`) puis testait la
+ * collision. Deux conséquences :
+ *
+ *   - un obus rapide pouvait traverser un mur entre deux pas ;
+ *   - une fois l'obus **dans** le mur, il fallait deviner par quelle face il
+ *     était entré. Le code comparait les quatre chevauchements et retenait le
+ *     plus petit — ce qui est faux dans les coins et faux dès que la
+ *     pénétration est profonde, d'où les rebonds erratiques.
+ *
+ * Le balayage donne l'instant et la face exacts, sans avoir à deviner. Il rend
+ * aussi la physique insensible à la vitesse, ce qui compte puisque le panneau
+ * de calibration (#10) permettra de la modifier.
+ */
+export function sweepBoxAgainstGrid(
+  grid: Grid,
+  centerX: number,
+  centerY: number,
+  halfSize: number,
+  dx: number,
+  dy: number,
+  isSolid: SolidityTest,
+): SweepHit | null {
+  if (dx === 0 && dy === 0) return null;
+
+  // Phase large : uniquement les tuiles que le trajet peut atteindre.
+  const minTileX = Math.floor(Math.min(centerX, centerX + dx) - halfSize);
+  const maxTileX = Math.floor(Math.max(centerX, centerX + dx) + halfSize);
+  const minTileY = Math.floor(Math.min(centerY, centerY + dy) - halfSize);
+  const maxTileY = Math.floor(Math.max(centerY, centerY + dy) + halfSize);
+
+  let earliest = Number.POSITIVE_INFINITY;
+  let normalX = 0;
+  let normalY = 0;
+
+  for (let tileY = minTileY; tileY <= maxTileY; tileY++) {
+    for (let tileX = minTileX; tileX <= maxTileX; tileX++) {
+      if (!isSolid(tileAt(grid, tileX, tileY))) continue;
+
+      const hit = sweepAgainstTile(
+        grid,
+        isSolid,
+        centerX,
+        centerY,
+        halfSize,
+        dx,
+        dy,
+        tileX,
+        tileY,
+      );
+      if (!hit) continue;
+
+      if (hit.time < earliest - SIMULTANEOUS_HIT_TOLERANCE) {
+        // Impact strictement plus précoce : il remplace les précédents.
+        earliest = hit.time;
+        normalX = 0;
+        normalY = 0;
+      } else if (hit.time > earliest + SIMULTANEOUS_HIT_TOLERANCE) {
+        continue;
+      }
+
+      // Impact simultané : on cumule les normales. Un obus qui entre dans un
+      // angle rentrant touche deux tuiles au même instant et doit repartir
+      // dans la direction opposée, pas le long du mur.
+      if (hit.entryX > hit.entryY + SIMULTANEOUS_HIT_TOLERANCE) {
+        normalX = dx > 0 ? -1 : 1;
+      } else if (hit.entryY > hit.entryX + SIMULTANEOUS_HIT_TOLERANCE) {
+        normalY = dy > 0 ? -1 : 1;
+      } else {
+        // Coin frappé exactement : les deux axes entrent en même temps.
+        normalX = dx > 0 ? -1 : 1;
+        normalY = dy > 0 ? -1 : 1;
+      }
+    }
+  }
+
+  if (!Number.isFinite(earliest)) return null;
+  return { time: earliest, normalX, normalY };
+}

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -97,10 +97,21 @@ export interface Tank {
 
 /* ── Projectiles ──────────────────────────────────────────────────────────── */
 
+/**
+ * Type de projectile.
+ *
+ * Détermine la vitesse et l'apparence. Le nombre de rebonds est porté
+ * séparément par `bouncesLeft` : le tank vert tire un missile rapide **avec**
+ * deux rebonds, donc les deux caractéristiques ne sont pas liées.
+ */
+export type ShellKind = 'normal' | 'fast';
+
 export interface Shell {
   id: EntityId;
   /** Tank qui a tiré. L'obus reste mortel pour lui après ricochet. */
   ownerId: EntityId;
+
+  kind: ShellKind;
 
   /** Position du centre, en tuiles. */
   x: number;
@@ -111,10 +122,18 @@ export interface Shell {
 
   /**
    * Rebonds encore autorisés. À zéro, le prochain contact détruit l'obus.
-   * Dépend du type d'obus : 1 pour un obus normal, 0 pour un missile, 2 pour
-   * l'obus du tank vert.
+   * 1 pour un obus normal, 0 pour un missile, 2 pour l'obus du tank vert.
    */
   bouncesLeft: number;
+
+  /**
+   * L'obus est-il devenu dangereux pour celui qui l'a tiré ?
+   *
+   * Faux tant que l'obus chevauche encore son tireur — sinon il le tuerait dès
+   * la sortie du canon. Il s'arme dès qu'il l'a quitté, ce qui reproduit la
+   * règle de l'original : **on peut se tuer soi-même avec son propre ricochet**.
+   */
+  armed: boolean;
 }
 
 export interface Mine {

--- a/src/core/systems/damage.ts
+++ b/src/core/systems/damage.ts
@@ -1,0 +1,97 @@
+/**
+ * Résolution des impacts.
+ *
+ * Une règle unique et sans nuance, reprise de l'original : **un obus tue en un
+ * coup**, quel que soit le tank touché — ennemi, coéquipier, ou celui qui l'a
+ * tiré.
+ *
+ * Comme dans `shells.ts`, rien n'est retiré pendant le parcours : on marque, et
+ * le compactage a lieu en fin de pas.
+ */
+
+import { TUNING } from '../tuning.js';
+import type { EntityId, Shell, Tank, World } from '../state.js';
+
+/**
+ * Distance du centre d'un cercle au point le plus proche d'une boîte.
+ *
+ * Le tank est une AABB, l'obus un disque : les comparer par distance entre
+ * centres — ce que faisait l'ancienne version avec un rayon unique déduit de
+ * `max(largeur, hauteur)` — donne une zone de touche circulaire nettement plus
+ * large que le tank aux quatre coins.
+ */
+function circleOverlapsBox(
+  circleX: number,
+  circleY: number,
+  radius: number,
+  boxX: number,
+  boxY: number,
+  boxHalf: number,
+): boolean {
+  const nearestX = Math.max(boxX - boxHalf, Math.min(circleX, boxX + boxHalf));
+  const nearestY = Math.max(boxY - boxHalf, Math.min(circleY, boxY + boxHalf));
+
+  const dx = circleX - nearestX;
+  const dy = circleY - nearestY;
+
+  return dx * dx + dy * dy < radius * radius;
+}
+
+/** Un obus peut-il toucher ce tank ? */
+function canHit(shell: Shell, tank: Tank): boolean {
+  if (!tank.alive) return false;
+  // Un obus qui n'a pas encore quitté son canon ne tue pas son tireur.
+  if (tank.id === shell.ownerId && !shell.armed) return false;
+  return true;
+}
+
+/** Obus contre tanks. Un obus qui touche est consommé. */
+export function resolveShellTankHits(world: World, doomed: Set<EntityId>): void {
+  const shellRadius = TUNING.shell.radiusTiles;
+  const tankHalf = TUNING.tank.sizeTiles / 2;
+
+  for (const shell of world.shells) {
+    if (doomed.has(shell.id)) continue;
+
+    for (const tank of world.tanks) {
+      if (!canHit(shell, tank)) continue;
+
+      if (circleOverlapsBox(shell.x, shell.y, shellRadius, tank.x, tank.y, tankHalf)) {
+        tank.alive = false;
+        doomed.add(shell.id);
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Obus contre obus : les deux explosent.
+ *
+ * L'ancienne version tentait déjà ce comportement, mais collectait des indices
+ * de tableau qu'elle invalidait ensuite en supprimant les éléments un à un.
+ * On travaille ici sur des identifiants, qui restent valides quoi qu'il arrive.
+ */
+export function resolveShellShellHits(world: World, doomed: Set<EntityId>): void {
+  const radius = TUNING.shell.radiusTiles;
+  const contactSquared = (radius * 2) * (radius * 2);
+
+  for (let i = 0; i < world.shells.length; i++) {
+    const first = world.shells[i]!;
+    if (doomed.has(first.id)) continue;
+
+    for (let j = i + 1; j < world.shells.length; j++) {
+      const second = world.shells[j]!;
+      if (doomed.has(second.id)) continue;
+
+      const dx = first.x - second.x;
+      const dy = first.y - second.y;
+
+      if (dx * dx + dy * dy < contactSquared) {
+        doomed.add(first.id);
+        doomed.add(second.id);
+        break;
+      }
+    }
+  }
+}

--- a/src/core/systems/shells.ts
+++ b/src/core/systems/shells.ts
@@ -1,0 +1,206 @@
+/**
+ * Tirs et trajectoire des obus.
+ *
+ * C'est la partie la plus caractéristique du jeu : un obus qui ricoche fait le
+ * tour d'une pièce et revient vous chercher. Elle était aussi la plus cassée
+ * dans l'ancienne version — trois bugs distincts, tous corrigés ici et couverts
+ * par les tests.
+ */
+
+import { blocksShell, boxOverlapsSolid, sweepBoxAgainstGrid } from '../grid.js';
+import { DT, secondsToTicks } from '../tick.js';
+import { TUNING } from '../tuning.js';
+import { allocateEntityId } from '../world.js';
+import type { EntityId, InputCommand, Shell, ShellKind, Tank, World } from '../state.js';
+
+/**
+ * Nombre maximal de rebonds traités dans un même pas.
+ *
+ * Un obus ne parcourt qu'une fraction de tuile par pas, donc un seul rebond est
+ * la règle et deux l'exception (un angle). Le plafond n'existe que pour garantir
+ * la terminaison si une géométrie dégénérée piégeait l'obus.
+ */
+const MAX_BOUNCES_PER_TICK = 8;
+
+/** Écart laissé entre l'obus et le mur après un rebond. */
+const SEPARATION_EPSILON = 1e-6;
+
+/** Caractéristiques de tir, fournies par le profil du tank (#11). */
+export interface ShellSpec {
+  kind: ShellKind;
+  bounces: number;
+}
+
+/** Le joueur tire des obus normaux à un rebond, comme dans l'original. */
+const PLAYER_SHELL: ShellSpec = { kind: 'normal', bounces: 1 };
+
+/** Vitesse associée à un type d'obus, en tuiles par seconde. */
+export function shellSpeed(kind: ShellKind): number {
+  return kind === 'fast'
+    ? TUNING.shell.fastSpeedTilesPerSecond
+    : TUNING.shell.normalSpeedTilesPerSecond;
+}
+
+/**
+ * Fait tirer un tank, si son quota et son rechargement le permettent.
+ *
+ * @returns l'obus créé, ou `null` si le tir a été refusé
+ */
+export function fireShell(world: World, tank: Tank, spec: ShellSpec = PLAYER_SHELL): Shell | null {
+  if (!tank.alive) return null;
+  if (tank.reloadTicks > 0) return null;
+  if (tank.activeShells >= TUNING.tank.maxActiveShells) return null;
+
+  const speed = shellSpeed(spec.kind);
+  const dirX = Math.cos(tank.turretAngle);
+  const dirY = Math.sin(tank.turretAngle);
+
+  // L'obus naît au bout du canon. Si ce point tombe dans un mur — canon collé
+  // contre un bloc — on le fait naître au centre du tank : le faire apparaître
+  // à l'intérieur du mur donnerait un rebond dans une direction arbitraire.
+  const muzzle = TUNING.tank.sizeTiles * 0.55;
+  const half = TUNING.shell.radiusTiles;
+  let x = tank.x + dirX * muzzle;
+  let y = tank.y + dirY * muzzle;
+
+  if (boxOverlapsSolid(world.grid, x, y, half, blocksShell)) {
+    x = tank.x;
+    y = tank.y;
+    // Même le centre du tank peut être muré après une destruction de terrain :
+    // dans ce cas on refuse le tir plutôt que de créer un obus prisonnier.
+    if (boxOverlapsSolid(world.grid, x, y, half, blocksShell)) return null;
+  }
+
+  const shell: Shell = {
+    id: allocateEntityId(world),
+    ownerId: tank.id,
+    kind: spec.kind,
+    x,
+    y,
+    vx: dirX * speed,
+    vy: dirY * speed,
+    bouncesLeft: spec.bounces,
+    // L'obus part désarmé : il chevauche encore son tireur.
+    armed: false,
+  };
+
+  world.shells.push(shell);
+  tank.activeShells++;
+  tank.reloadTicks = secondsToTicks(TUNING.shell.cooldownSeconds);
+
+  return shell;
+}
+
+/** Traite les intentions de tir du pas courant. */
+export function updateFiring(world: World, intents: ReadonlyMap<EntityId, InputCommand>): void {
+  for (const tank of world.tanks) {
+    const input = intents.get(tank.id);
+    if (input?.fire) fireShell(world, tank);
+  }
+}
+
+/**
+ * Fait avancer un obus d'un pas, en traitant les rebonds rencontrés.
+ *
+ * @returns `false` si l'obus doit être détruit
+ */
+function advanceShell(world: World, shell: Shell): boolean {
+  const half = TUNING.shell.radiusTiles;
+
+  // Filet de sécurité : un obus qui se retrouverait dans un mur — terrain
+  // reconstruit sous lui, par exemple — est détruit plutôt que de traverser.
+  if (boxOverlapsSolid(world.grid, shell.x, shell.y, half, blocksShell)) return false;
+
+  let remaining = DT;
+
+  for (let iteration = 0; iteration < MAX_BOUNCES_PER_TICK; iteration++) {
+    const dx = shell.vx * remaining;
+    const dy = shell.vy * remaining;
+
+    const hit = sweepBoxAgainstGrid(world.grid, shell.x, shell.y, half, dx, dy, blocksShell);
+
+    if (!hit) {
+      shell.x += dx;
+      shell.y += dy;
+      return true;
+    }
+
+    // On avance jusqu'au point de contact, puis on décolle légèrement du mur
+    // pour que l'itération suivante ne redétecte pas le même impact.
+    shell.x += dx * hit.time + hit.normalX * SEPARATION_EPSILON;
+    shell.y += dy * hit.time + hit.normalY * SEPARATION_EPSILON;
+
+    // Quota épuisé : l'obus explose au contact au lieu de repartir.
+    if (shell.bouncesLeft <= 0) return false;
+    shell.bouncesLeft--;
+
+    // Réflexion sur la normale de la face effectivement traversée. Dans un
+    // angle rentrant, les deux composantes s'inversent.
+    if (hit.normalX !== 0) shell.vx = -shell.vx;
+    if (hit.normalY !== 0) shell.vy = -shell.vy;
+
+    remaining *= 1 - hit.time;
+    if (remaining <= 0) return true;
+  }
+
+  return true;
+}
+
+/**
+ * Arme l'obus dès qu'il a quitté son tireur.
+ *
+ * Tant qu'il le chevauche, il lui est inoffensif — sinon il le tuerait à la
+ * sortie du canon. Une fois armé, il redevient mortel pour tout le monde,
+ * tireur compris : c'est ce qui permet de se tuer avec son propre ricochet.
+ */
+function updateArming(world: World, shell: Shell): void {
+  if (shell.armed) return;
+
+  const owner = world.tanks.find((tank) => tank.id === shell.ownerId);
+  if (!owner) {
+    shell.armed = true;
+    return;
+  }
+
+  const reach = TUNING.tank.sizeTiles / 2 + TUNING.shell.radiusTiles;
+  const clearOfOwner =
+    Math.abs(shell.x - owner.x) > reach || Math.abs(shell.y - owner.y) > reach;
+
+  if (clearOfOwner) shell.armed = true;
+}
+
+/**
+ * Fait avancer tous les obus et retire ceux qui ont fini leur course.
+ *
+ * Les obus condamnés sont **marqués** puis retirés en fin de passe. Modifier le
+ * tableau pendant qu'on le parcourt est ce qui faisait sauter un obus sur deux
+ * dans l'ancienne boucle : chaque `splice` décalait les indices restants.
+ */
+export function updateShells(world: World, doomed: Set<EntityId>): void {
+  for (const shell of world.shells) {
+    if (doomed.has(shell.id)) continue;
+
+    if (!advanceShell(world, shell)) {
+      doomed.add(shell.id);
+      continue;
+    }
+
+    updateArming(world, shell);
+  }
+}
+
+/** Retire les obus condamnés et rend son quota à chaque tireur. */
+export function removeDoomedShells(world: World, doomed: ReadonlySet<EntityId>): void {
+  if (doomed.size === 0) return;
+
+  let kept = 0;
+  for (const shell of world.shells) {
+    if (doomed.has(shell.id)) {
+      const owner = world.tanks.find((tank) => tank.id === shell.ownerId);
+      if (owner && owner.activeShells > 0) owner.activeShells--;
+      continue;
+    }
+    world.shells[kept++] = shell;
+  }
+  world.shells.length = kept;
+}

--- a/src/core/tick.ts
+++ b/src/core/tick.ts
@@ -14,8 +14,10 @@
  * dérivaient l'un de l'autre.
  */
 
+import { resolveShellShellHits, resolveShellTankHits } from './systems/damage.js';
 import { updateMovement } from './systems/movement.js';
-import type { InputCommand, World } from './state.js';
+import { removeDoomedShells, updateFiring, updateShells } from './systems/shells.js';
+import type { EntityId, InputCommand, World } from './state.js';
 
 /**
  * Fréquence de simulation, en pas par seconde.
@@ -41,7 +43,7 @@ export function secondsToTicks(seconds: number): number {
  * Un tableau de paires plutôt qu'une `Map` : le monde et ses entrées doivent
  * rester sérialisables tels quels pour l'enregistrement et le rejeu.
  */
-export type TickInputs = ReadonlyArray<readonly [tankId: number, input: InputCommand]>;
+export type TickInputs = ReadonlyArray<readonly [tankId: EntityId, input: InputCommand]>;
 
 /**
  * Fait avancer le monde d'exactement un pas.
@@ -62,15 +64,29 @@ export function tick(world: World, inputs: TickInputs): void {
   // 2. Déplacement des tanks : résolution X puis Y, glissement le long des murs.
   updateMovement(world, intents);
 
-  // 3. Déplacement des obus       → #8  (intégration balayée, rebonds)
-  // 4. Mèches et détonations      → #9  (mines, explosions, destruction du terrain)
-  // 5. Résolution des dégâts      → #8/#9 (obus↔tank, obus↔obus, explosion↔entités)
+  // 3. Tirs, après le déplacement : l'obus part de la position finale du tank.
+  updateFiring(world, intents);
+
+  // Entités condamnées durant ce pas. Volontairement local et non stocké dans
+  // le monde : retirer une entité en cours de parcours décalerait les indices
+  // et ferait sauter la suivante — c'est le bug qui rendait la détection de
+  // collisions inopérante dans l'ancienne version.
+  const doomed = new Set<EntityId>();
+
+  // 4. Trajectoire des obus : balayage continu et rebonds.
+  updateShells(world, doomed);
+
+  // 5. Mèches et détonations → #9 (mines, explosions, destruction du terrain)
+
+  // 6. Impacts. Obus contre obus d'abord : deux obus qui se croisent
+  //    s'annulent, même si l'un d'eux atteignait un tank au même pas.
+  resolveShellShellHits(world, doomed);
+  resolveShellTankHits(world, doomed);
 
   advanceTimers(world);
 
-  // 6. Compactage : les entités marquées mortes disparaissent ici, et seulement
-  //    ici. Supprimer en cours d'itération est ce qui faisait « sauter » un obus
-  //    sur deux dans l'ancienne boucle (`splice` pendant un `forEach`).
+  // 7. Compactage : les entités marquées disparaissent ici, et seulement ici.
+  removeDoomedShells(world, doomed);
   removeExpiredExplosions(world);
 
   world.tick++;

--- a/tests/shells.test.ts
+++ b/tests/shells.test.ts
@@ -1,0 +1,611 @@
+import { describe, expect, test } from 'bun:test';
+
+import { blocksShell, setTile, sweepBoxAgainstGrid } from '../src/core/grid.js';
+import { TileKind } from '../src/core/state.js';
+import type { InputCommand, Shell, Tank, World } from '../src/core/state.js';
+import { TICK_RATE, tick } from '../src/core/tick.js';
+import type { TickInputs } from '../src/core/tick.js';
+import { fireShell, shellSpeed } from '../src/core/systems/shells.js';
+import { REFERENCE_MEASUREMENTS, TILE_SIZE_PX, TUNING } from '../src/core/tuning.js';
+import { allocateEntityId, createWorld, hashWorld } from '../src/core/world.js';
+
+function openWorld(width = 40, height = 30): World {
+  return createWorld({ width, height, seed: 1 });
+}
+
+function addTank(world: World, x: number, y: number, turretAngle = 0): Tank {
+  const tank: Tank = {
+    id: allocateEntityId(world),
+    color: 'player',
+    playerId: null,
+    x,
+    y,
+    bodyAngle: 0,
+    turretAngle,
+    alive: true,
+    activeShells: 0,
+    activeMines: 0,
+    reloadTicks: 0,
+  };
+  world.tanks.push(tank);
+  return tank;
+}
+
+/** Pose un obus directement, sans passer par un tank — pour tester la trajectoire seule. */
+function addShell(world: World, options: Partial<Shell> & { x: number; y: number }): Shell {
+  const shell: Shell = {
+    id: allocateEntityId(world),
+    ownerId: -1,
+    kind: 'normal',
+    vx: 0,
+    vy: 0,
+    bouncesLeft: 1,
+    armed: true,
+    ...options,
+  };
+  world.shells.push(shell);
+  return shell;
+}
+
+function input(overrides: Partial<InputCommand> = {}): InputCommand {
+  return { moveX: 0, moveY: 0, aim: 0, fire: false, mine: false, ...overrides };
+}
+
+const NO_INPUTS: TickInputs = [];
+
+function advance(world: World, ticks: number, inputs: TickInputs = NO_INPUTS): void {
+  for (let i = 0; i < ticks; i++) tick(world, inputs);
+}
+
+describe('vitesse des obus — conformité à la mesure de référence', () => {
+  test('un obus normal traverse l\'arène de référence dans le temps mesuré', () => {
+    // Fait observable relevé sur le jeu original : un obus parcourt 736 px en 4 s.
+    const distanceTiles = REFERENCE_MEASUREMENTS.arenaWidthPx / TILE_SIZE_PX;
+    const expectedTicks = REFERENCE_MEASUREMENTS.shellCrossingSeconds * TICK_RATE;
+
+    const world = openWorld(Math.ceil(distanceTiles) + 8, 10);
+    const shell = addShell(world, {
+      x: 2,
+      y: 5,
+      vx: shellSpeed('normal'),
+      // Beaucoup de rebonds : on mesure la distance parcourue, pas la survie.
+      bouncesLeft: 999,
+    });
+    const startX = shell.x;
+
+    let ticks = 0;
+    while (shell.x - startX < distanceTiles && ticks < expectedTicks * 3) {
+      advance(world, 1);
+      ticks++;
+    }
+
+    expect(Math.abs(ticks - expectedTicks)).toBeLessThanOrEqual(1);
+  });
+
+  test('un missile va exactement deux fois plus vite', () => {
+    expect(shellSpeed('fast')).toBeCloseTo(shellSpeed('normal') * 2, 9);
+  });
+});
+
+describe('rebonds', () => {
+  test('un obus à 30° sur un mur horizontal repart à -30°, module conservé', () => {
+    const world = openWorld(30, 20);
+    for (let x = 1; x < 29; x++) setTile(world.grid, x, 10, TileKind.Indestructible);
+
+    const angle = Math.PI / 6;
+    const speed = shellSpeed('normal');
+    const shell = addShell(world, {
+      x: 15,
+      y: 8,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+    });
+
+    advance(world, 120);
+
+    expect(world.shells).toHaveLength(1);
+    // Composante horizontale inchangée, verticale inversée.
+    expect(shell.vx).toBeCloseTo(Math.cos(angle) * speed, 9);
+    expect(shell.vy).toBeCloseTo(-Math.sin(angle) * speed, 9);
+    // Le module est conservé : un rebond ne freine pas.
+    expect(Math.hypot(shell.vx, shell.vy)).toBeCloseTo(speed, 9);
+  });
+
+  test('un obus vertical sur un mur horizontal repart exactement à l\'opposé', () => {
+    const world = openWorld(20, 20);
+    for (let x = 1; x < 19; x++) setTile(world.grid, x, 10, TileKind.Indestructible);
+
+    const speed = shellSpeed('normal');
+    const shell = addShell(world, { x: 5.5, y: 5, vy: speed, bouncesLeft: 1 });
+
+    advance(world, 120);
+
+    expect(shell.vy).toBeCloseTo(-speed, 9);
+    expect(shell.vx).toBeCloseTo(0, 9);
+  });
+
+  test('à 45° contre un mur plat, seule la composante perpendiculaire s\'inverse', () => {
+    // Non-régression d'un bug d'arêtes internes. Chaque tuile étant testée
+    // isolément, la face gauche de la tuile voisine — enfouie dans le mur, donc
+    // inexistante — était traitée comme une vraie surface. À 45°, elle est
+    // atteinte exactement en même temps que la face supérieure : les deux
+    // normales se cumulaient et l'obus repartait d'où il venait.
+    //
+    // Le symptôme ne se manifeste qu'aux angles où les deux entrées coïncident,
+    // ce qui le rend indétectable avec des tirs à 30° ou perpendiculaires.
+    const world = openWorld(24, 14);
+    const speed = shellSpeed('normal');
+
+    const shell = addShell(world, {
+      x: 2.5,
+      y: 11.5,
+      vx: speed * Math.SQRT1_2,
+      vy: -speed * Math.SQRT1_2,
+      bouncesLeft: 5,
+    });
+
+    // Jusqu'au premier contact avec la bordure supérieure.
+    while (world.shells.length > 0 && shell.vy < 0) advance(world, 1);
+
+    expect(world.shells).toHaveLength(1);
+    // La composante horizontale doit être intacte : l'obus continue vers la
+    // droite. Si elle s'était inversée, il reviendrait sur ses pas.
+    expect(shell.vx).toBeCloseTo(speed * Math.SQRT1_2, 6);
+    expect(shell.vy).toBeCloseTo(speed * Math.SQRT1_2, 6);
+  });
+
+  test('à 45° dans chaque coin, l\'obus longe le billard sans revenir sur ses pas', () => {
+    // Les quatre diagonales contre les quatre bordures, pour couvrir les
+    // combinaisons de signes du masquage d'arêtes.
+    const speed = shellSpeed('normal');
+
+    for (const [dirX, dirY] of [
+      [1, -1],
+      [1, 1],
+      [-1, 1],
+      [-1, -1],
+    ] as const) {
+      // Point de départ volontairement asymétrique : depuis le centre, les
+      // distances aux quatre bordures seraient égales et l'obus atteindrait
+      // deux murs au même instant — un vrai coin, où l'inversion des deux
+      // composantes est le comportement attendu (cas couvert par le test
+      // suivant).
+      const world = openWorld(20, 20);
+      const shell = addShell(world, {
+        x: 6.5,
+        y: 11.5,
+        vx: dirX * speed * Math.SQRT1_2,
+        vy: dirY * speed * Math.SQRT1_2,
+        bouncesLeft: 3,
+      });
+
+      const initialVx = shell.vx;
+      const initialVy = shell.vy;
+
+      while (world.shells.length > 0 && shell.vx === initialVx && shell.vy === initialVy) {
+        advance(world, 1);
+      }
+
+      expect(world.shells).toHaveLength(1);
+      // Exactement une composante a changé de signe, jamais les deux.
+      const flippedX = shell.vx !== initialVx;
+      const flippedY = shell.vy !== initialVy;
+      expect(flippedX !== flippedY).toBe(true);
+    }
+  });
+
+  test('un angle rentrant inverse les deux composantes', () => {
+    // Deux murs perpendiculaires touchés au même instant : l'obus doit repartir
+    // d'où il vient. Les traiter l'un après l'autre le renverrait le long du mur.
+    const world = openWorld(20, 20);
+    for (let x = 10; x < 19; x++) setTile(world.grid, x, 10, TileKind.Indestructible);
+    for (let y = 10; y < 19; y++) setTile(world.grid, 10, y, TileKind.Indestructible);
+
+    const speed = shellSpeed('normal');
+    const shell = addShell(world, {
+      x: 8,
+      y: 8,
+      // Trajectoire à 45° visant exactement le sommet du coin en (10, 10).
+      vx: speed * Math.SQRT1_2,
+      vy: speed * Math.SQRT1_2,
+      bouncesLeft: 5,
+    });
+
+    advance(world, 120);
+
+    expect(shell.vx).toBeLessThan(0);
+    expect(shell.vy).toBeLessThan(0);
+  });
+
+  test('un obus rebondit indéfiniment entre deux murs si son quota le permet', () => {
+    const world = openWorld(20, 20);
+    for (let x = 1; x < 19; x++) {
+      setTile(world.grid, x, 5, TileKind.Indestructible);
+      setTile(world.grid, x, 12, TileKind.Indestructible);
+    }
+
+    const shell = addShell(world, {
+      x: 10.5,
+      y: 8,
+      vy: shellSpeed('normal'),
+      bouncesLeft: 50,
+    });
+
+    advance(world, 600);
+
+    expect(world.shells).toHaveLength(1);
+    // Il est resté confiné entre les deux murs.
+    expect(shell.y).toBeGreaterThan(5);
+    expect(shell.y).toBeLessThan(13);
+  });
+});
+
+describe('quota de rebonds', () => {
+  /** Compte les pas avant disparition d'un obus tiré verticalement dans un couloir. */
+  function ticksUntilGone(bounces: number, kind: 'normal' | 'fast' = 'normal'): number {
+    const world = openWorld(20, 20);
+    for (let x = 1; x < 19; x++) {
+      setTile(world.grid, x, 5, TileKind.Indestructible);
+      setTile(world.grid, x, 14, TileKind.Indestructible);
+    }
+    addShell(world, { x: 10.5, y: 9, vy: shellSpeed(kind), bouncesLeft: bounces, kind });
+
+    let ticks = 0;
+    while (world.shells.length > 0 && ticks < 5000) {
+      advance(world, 1);
+      ticks++;
+    }
+    return ticks;
+  }
+
+  test('un missile (0 rebond) explose au premier contact', () => {
+    // Il ne doit jamais faire demi-tour : la distance parcourue reste celle
+    // d'un aller simple.
+    const world = openWorld(20, 20);
+    for (let x = 1; x < 19; x++) setTile(world.grid, x, 14, TileKind.Indestructible);
+    addShell(world, { x: 10.5, y: 9, vy: shellSpeed('fast'), bouncesLeft: 0, kind: 'fast' });
+
+    let maxY = 0;
+    while (world.shells.length > 0) {
+      advance(world, 1);
+      const shell = world.shells[0];
+      if (shell) maxY = Math.max(maxY, shell.y);
+    }
+
+    expect(maxY).toBeLessThan(14);
+  });
+
+  test('plus le quota est élevé, plus l\'obus vit longtemps', () => {
+    const zero = ticksUntilGone(0);
+    const one = ticksUntilGone(1);
+    const two = ticksUntilGone(2);
+
+    expect(one).toBeGreaterThan(zero);
+    expect(two).toBeGreaterThan(one);
+
+    // Chaque rebond supplémentaire ajoute un aller-retour de longueur constante.
+    expect(two - one).toBeCloseTo(one - zero, -1);
+  });
+
+  test('un obus normal survit à un rebond et meurt au second contact', () => {
+    const world = openWorld(20, 20);
+    for (let x = 1; x < 19; x++) {
+      setTile(world.grid, x, 5, TileKind.Indestructible);
+      setTile(world.grid, x, 14, TileKind.Indestructible);
+    }
+    const shell = addShell(world, { x: 10.5, y: 9, vy: shellSpeed('normal'), bouncesLeft: 1 });
+
+    // Premier contact : il rebondit.
+    while (world.shells.length > 0 && shell.vy > 0) advance(world, 1);
+    expect(world.shells).toHaveLength(1);
+    expect(shell.bouncesLeft).toBe(0);
+
+    // Second contact : il disparaît.
+    while (world.shells.length > 0) advance(world, 1);
+    expect(world.shells).toHaveLength(0);
+  });
+});
+
+describe('étanchéité — aucun obus ne traverse un mur', () => {
+  test('balayage sur 360 angles contre un mur d\'une seule tuile d\'épaisseur', () => {
+    // Un seul angle qui passerait rendrait le jeu injouable, et ce genre de
+    // trou est indétectable à la main. On teste au double de la vitesse la plus
+    // rapide du jeu, pour garder de la marge quand le panneau de calibration
+    // (#10) permettra de l'augmenter.
+    const speed = shellSpeed('fast') * 2;
+    const escapes: number[] = [];
+
+    for (let degrees = 0; degrees < 360; degrees++) {
+      const radians = (degrees * Math.PI) / 180;
+      const world = createWorld({ width: 9, height: 9, seed: 1 });
+
+      addShell(world, {
+        x: 4.5,
+        y: 4.5,
+        vx: Math.cos(radians) * speed,
+        vy: Math.sin(radians) * speed,
+        bouncesLeft: 200,
+      });
+
+      advance(world, 400);
+
+      const shell = world.shells[0];
+      if (!shell) continue; // détruit : acceptable, jamais échappé
+
+      const inside = shell.x > 1 && shell.x < 8 && shell.y > 1 && shell.y < 8;
+      if (!inside) escapes.push(degrees);
+    }
+
+    expect(escapes).toEqual([]);
+  });
+
+  test('un obus ne franchit pas un mur isolé au milieu de sa trajectoire', () => {
+    const world = openWorld(30, 10);
+    for (let y = 1; y < 9; y++) setTile(world.grid, 15, y, TileKind.Indestructible);
+
+    const shell = addShell(world, {
+      x: 5,
+      y: 5,
+      vx: shellSpeed('fast'),
+      bouncesLeft: 1,
+    });
+
+    advance(world, 200);
+
+    // Qu'il ait rebondi ou disparu, il n'a jamais dépassé le mur.
+    if (world.shells.length > 0) expect(shell.x).toBeLessThan(15);
+  });
+
+  test('un obus survole un trou sans rebondir', () => {
+    const world = openWorld(30, 10);
+    for (let y = 1; y < 9; y++) setTile(world.grid, 15, y, TileKind.Hole);
+
+    const shell = addShell(world, { x: 5, y: 5, vx: shellSpeed('normal'), bouncesLeft: 1 });
+    advance(world, 200);
+
+    expect(shell.x).toBeGreaterThan(15);
+    expect(shell.vx).toBeGreaterThan(0);
+  });
+});
+
+describe('balayage — cas de base', () => {
+  test('aucun impact signalé sur un trajet libre', () => {
+    const world = openWorld(10, 10);
+    expect(sweepBoxAgainstGrid(world.grid, 5, 5, 0.1, 0.2, 0, blocksShell)).toBeNull();
+  });
+
+  test('l\'instant d\'impact correspond à la distance restante', () => {
+    const world = openWorld(10, 10);
+    setTile(world.grid, 7, 5, TileKind.Indestructible);
+
+    // Depuis x = 5 avec un rayon de 0,1, la face de la tuile est à 6,9 : il
+    // reste 1,9 à parcourir sur un déplacement de 3,8, soit la moitié.
+    const hit = sweepBoxAgainstGrid(world.grid, 5, 5.5, 0.1, 3.8, 0, blocksShell);
+
+    expect(hit).not.toBeNull();
+    expect(hit!.time).toBeCloseTo(0.5, 6);
+    expect(hit!.normalX).toBe(-1);
+    expect(hit!.normalY).toBe(0);
+  });
+
+  test('un déplacement nul ne produit aucun impact', () => {
+    const world = openWorld(10, 10);
+    expect(sweepBoxAgainstGrid(world.grid, 5, 5, 0.1, 0, 0, blocksShell)).toBeNull();
+  });
+});
+
+describe('tir', () => {
+  test('le tir respecte le quota d\'obus simultanés', () => {
+    const world = openWorld(40, 30);
+    const tank = addTank(world, 20, 15);
+
+    for (let i = 0; i < TUNING.tank.maxActiveShells + 3; i++) {
+      tank.reloadTicks = 0;
+      fireShell(world, tank);
+    }
+
+    expect(world.shells).toHaveLength(TUNING.tank.maxActiveShells);
+    expect(tank.activeShells).toBe(TUNING.tank.maxActiveShells);
+  });
+
+  test('le quota est rendu quand un obus disparaît', () => {
+    const world = openWorld(12, 12);
+    const tank = addTank(world, 6, 6);
+
+    fireShell(world, tank);
+    expect(tank.activeShells).toBe(1);
+
+    // L'obus finit par heurter la bordure deux fois et disparaître.
+    advance(world, 600);
+
+    expect(world.shells).toHaveLength(0);
+    expect(tank.activeShells).toBe(0);
+  });
+
+  test('le rechargement impose un délai entre deux tirs', () => {
+    const world = openWorld(40, 30);
+    const tank = addTank(world, 20, 15);
+
+    expect(fireShell(world, tank)).not.toBeNull();
+    expect(fireShell(world, tank)).toBeNull();
+
+    advance(world, tank.reloadTicks + 1);
+    expect(fireShell(world, tank)).not.toBeNull();
+  });
+
+  test('un tank mort ne tire pas', () => {
+    const world = openWorld(40, 30);
+    const tank = addTank(world, 20, 15);
+    tank.alive = false;
+
+    expect(fireShell(world, tank)).toBeNull();
+  });
+
+  test('l\'obus part dans la direction de la tourelle, pas du châssis', () => {
+    const world = openWorld(40, 30);
+    const tank = addTank(world, 20, 15, Math.PI / 2);
+    tank.bodyAngle = 0;
+
+    const shell = fireShell(world, tank);
+
+    expect(shell).not.toBeNull();
+    expect(shell!.vy).toBeGreaterThan(0);
+    expect(Math.abs(shell!.vx)).toBeLessThan(1e-9);
+  });
+
+  test('canon collé contre un mur, l\'obus ne naît pas dans le mur', () => {
+    const world = openWorld(20, 20);
+    for (let y = 1; y < 19; y++) setTile(world.grid, 10, y, TileKind.Indestructible);
+
+    // Tank plaqué contre le mur, canon pointé dedans.
+    const tank = addTank(world, 10 - TUNING.tank.sizeTiles / 2 - 0.01, 10, 0);
+    const shell = fireShell(world, tank);
+
+    expect(shell).not.toBeNull();
+    expect(shell!.x).toBeLessThan(10);
+
+    // Et il ne traverse pas non plus au pas suivant.
+    advance(world, 5);
+    const survivor = world.shells[0];
+    if (survivor) expect(survivor.x).toBeLessThan(10);
+  });
+
+  test('la touche de tir déclenche le tir via le cycle normal', () => {
+    const world = openWorld(40, 30);
+    const tank = addTank(world, 20, 15);
+
+    advance(world, 1, [[tank.id, input({ fire: true })]]);
+
+    expect(world.shells).toHaveLength(1);
+  });
+});
+
+describe('impacts', () => {
+  test('un obus tue un tank en un seul coup', () => {
+    const world = openWorld(40, 20);
+    const target = addTank(world, 20, 10);
+    addShell(world, { x: 15, y: 10, vx: shellSpeed('normal') });
+
+    advance(world, 120);
+
+    expect(target.alive).toBe(false);
+    expect(world.shells).toHaveLength(0);
+  });
+
+  test('un obus ne tue pas son tireur à la sortie du canon', () => {
+    const world = openWorld(40, 30);
+    const tank = addTank(world, 20, 15);
+
+    fireShell(world, tank);
+    advance(world, 3);
+
+    expect(tank.alive).toBe(true);
+  });
+
+  test('on peut se tuer soi-même avec son propre ricochet', () => {
+    // Le comportement signature du jeu : l'obus reste mortel pour son tireur
+    // une fois qu'il a quitté le canon.
+    const world = openWorld(20, 20);
+    for (let x = 1; x < 19; x++) setTile(world.grid, x, 5, TileKind.Indestructible);
+
+    // Tank visant le mur droit au-dessus de lui.
+    const tank = addTank(world, 10.5, 10, -Math.PI / 2);
+    fireShell(world, tank);
+
+    advance(world, 300);
+
+    expect(tank.alive).toBe(false);
+  });
+
+  test('deux obus qui se croisent s\'annulent', () => {
+    const world = openWorld(40, 20);
+    const speed = shellSpeed('normal');
+
+    addShell(world, { x: 15, y: 10, vx: speed });
+    addShell(world, { x: 25, y: 10, vx: -speed });
+
+    advance(world, 120);
+
+    expect(world.shells).toHaveLength(0);
+  });
+
+  test('un obus ne touche pas un tank déjà détruit', () => {
+    const world = openWorld(40, 20);
+    const target = addTank(world, 20, 10);
+    target.alive = false;
+
+    const shell = addShell(world, { x: 15, y: 10, vx: shellSpeed('normal'), bouncesLeft: 5 });
+    advance(world, 60);
+
+    // Il a traversé sans être consommé.
+    expect(world.shells).toHaveLength(1);
+    expect(shell.x).toBeGreaterThan(20);
+  });
+
+  test('la zone de touche épouse la boîte du tank, pas un cercle circonscrit', () => {
+    // L'ancienne version comparait la distance entre centres à un rayon déduit
+    // de max(largeur, hauteur), ce qui rendait les tanks touchables bien
+    // au-delà de leurs coins.
+    const world = openWorld(40, 20);
+    const target = addTank(world, 20, 10);
+
+    // Passe au ras du coin, en dehors de la boîte.
+    const clearance = TUNING.tank.sizeTiles / 2 + TUNING.shell.radiusTiles + 0.02;
+    addShell(world, { x: 15, y: 10 + clearance, vx: shellSpeed('normal'), bouncesLeft: 5 });
+
+    advance(world, 60);
+
+    expect(target.alive).toBe(true);
+  });
+});
+
+describe('robustesse du parcours', () => {
+  test('la disparition simultanée de plusieurs obus n\'en fait sauter aucun', () => {
+    // Le bug le plus insidieux de l'ancienne boucle : `splice` pendant un
+    // `forEach` décalait les indices, donc l'obus suivant n'était ni déplacé ni
+    // testé pour ce pas.
+    const world = openWorld(60, 20);
+    const speed = shellSpeed('normal');
+
+    // Cinq paires frontales, qui s'annuleront toutes au même pas.
+    for (let pair = 0; pair < 5; pair++) {
+      const y = 3 + pair * 3;
+      addShell(world, { x: 29, y, vx: speed });
+      addShell(world, { x: 31, y, vx: -speed });
+    }
+    // Plus un obus isolé, qui doit survivre et avoir avancé normalement.
+    const survivor = addShell(world, { x: 5, y: 18, vx: speed, bouncesLeft: 9 });
+    const startX = survivor.x;
+
+    advance(world, 30);
+
+    expect(world.shells).toHaveLength(1);
+    expect(world.shells[0]!.id).toBe(survivor.id);
+    expect(survivor.x - startX).toBeCloseTo((speed * 30) / TICK_RATE, 6);
+  });
+
+  test('la trajectoire est déterministe', () => {
+    const build = (): World => {
+      const world = openWorld(20, 20);
+      for (let x = 1; x < 19; x++) setTile(world.grid, x, 5, TileKind.Indestructible);
+      for (let y = 1; y < 19; y++) setTile(world.grid, 14, y, TileKind.Indestructible);
+
+      const speed = shellSpeed('normal');
+      addShell(world, {
+        x: 8,
+        y: 10,
+        vx: speed * 0.8,
+        vy: -speed * 0.6,
+        bouncesLeft: 20,
+      });
+      return world;
+    };
+
+    const a = build();
+    const b = build();
+    advance(a, 900);
+    advance(b, 900);
+
+    expect(hashWorld(a)).toBe(hashWorld(b));
+  });
+});

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -87,7 +87,7 @@ describe('interpolation', () => {
   test('une entité qui vient d\'apparaître est prise telle quelle', () => {
     // La faire glisser depuis une position d'origine inventée produirait un
     // fantôme traversant l'écran au moment du spawn.
-    const empty: RenderSnapshot = { tick: 0, tanks: [] };
+    const empty: RenderSnapshot = { tick: 0, tanks: [], shells: [] };
     const view = interpolateSnapshots(empty, current, 0.5).tanks[0]!;
 
     expect(view.x).toBe(4);


### PR DESCRIPTION
Closes #8

**On peut se tuer avec son propre ricochet.** C'est le comportement signature du jeu, et il fonctionne.

## Les trois bugs de l'ancienne version

### 1. Intégration non balayée

`Bullet.update()` déplaçait l'obus (`this.x += this.dx`) **puis** testait la collision. Un obus rapide pouvait traverser un mur entre deux pas.

Le balayage continu trouve le premier point d'impact du pas, avance jusqu'à lui, réfléchit, et consomme le temps restant. La physique devient insensible à la vitesse — ce qui compte, puisque le panneau de calibration (#10) permettra de la modifier.

### 2. Rebond deviné par « plus petit chevauchement »

Une fois l'obus **dans** le mur, l'ancien code comparait `overlapLeft / overlapRight / overlapTop / overlapBottom` pour deviner par quelle face il était entré. C'est faux dans les coins, et faux dès que la pénétration est profonde — d'où les rebonds erratiques.

Le balayage donne l'instant et la face **exacts**, sans rien deviner.

### 3. `splice()` pendant un `forEach`

```ts
bullets.forEach((bullet, index) => { ... bullets.splice(index, 1) ... })
```

Chaque suppression décalait le tableau : l'obus suivant n'était **ni déplacé ni testé** pour ce pas. Le même bug corrompait la détection obus↔obus, qui collectait des indices puis les invalidait en supprimant les éléments un à un.

On marque désormais par **identifiant** et on compacte en fin de tick. Un test de non-régression fait exploser cinq paires frontales au même pas et vérifie qu'un obus isolé a bien parcouru sa distance nominale.

## Un quatrième bug, découvert pendant l'implémentation : les arêtes internes

Celui-là n'existait pas dans l'ancien code — il n'allait pas jusque-là.

Chaque tuile étant testée isolément, la face gauche d'une tuile **enfouie dans un mur** était traitée comme une vraie surface de collision. À 45° contre un mur plat, cette face fantôme est atteinte exactement au même instant que la face supérieure de la tuile voisine : les deux normales se cumulaient et **l'obus repartait d'où il venait** au lieu de ricocher.

Diagnostic par trace de trajectoire :

```
avant                                  après
tick 154  v (4.07,-4.07) → (-4.07,4.07)   tick 154  v (4.07,-4.07) → ( 4.07, 4.07)
          ^ les deux composantes                    ^ seule la perpendiculaire
```

Une face n'est désormais retenue que si la tuile de l'autre côté est franchissable. Le symptôme ne se manifestant **qu'aux angles où les deux entrées coïncident**, il était invisible avec des tirs à 30° ou perpendiculaires — d'où un test de non-régression dédié, plus un test des quatre diagonales.

Les vrais coins rentrants, eux, inversent bien les deux composantes : les normales des tuiles touchées au même instant sont cumulées.

### Trajectoire après correction

Même tir à 45°, quota 1 puis 3 rebonds, avec un obstacle central :

```
quota 1 rebond                          quota 3 rebonds
████████████████████████                ████████████████████████
█···········**·········█                █···········**···***···█
█··········*·**········█                █··········*·**·**·**··█
█·········*···**·······█                █·········*···***···**·█
█········*··██████·····█                █········*··██████···**█
█·······*···█··········█                █·······*···█·········*█
█······*····█··········█                █······*····█··········█
█·····*·····█··········█                █·····*·····█··········█
█····*······█··········█                █····*······█··········█
█···*·······█··········█                █···*·······█··········█
█··*···················█                █··*···················█
█·T····················█                █·T····················█
████████████████████████                ████████████████████████
```

Un vrai parcours de billard.

## Autres points

**Armement.** Un obus reste inoffensif pour son tireur tant qu'il chevauche encore son canon, puis s'arme définitivement. C'est ce qui permet le suicide par ricochet sans tuer le joueur à bout portant.

**Zone de touche.** Elle épouse la boîte du tank (cercle contre AABB). L'ancienne version comparait la distance entre centres à un rayon déduit de `max(largeur, hauteur)`, ce qui rendait les tanks touchables bien au-delà de leurs quatre coins.

**Quotas.** 5 obus simultanés pour le joueur, rendus à la disparition de chaque obus. Les rebonds sont portés par obus : 1 pour un obus normal, 0 pour un missile, 2 pour celui du tank vert (#11).

**Naissance de l'obus.** Si le bout du canon tombe dans un mur — tank plaqué contre un bloc — l'obus naît au centre du tank plutôt qu'à l'intérieur du mur, où il rebondirait dans une direction arbitraire.

## Vérification

| Commande | Résultat |
|---|---|
| `bun test ./tests` | **108 passés**, 0 échec |
| `bunx tsc --noEmit` | aucune erreur |
| `bunx playwright test` | **9 passés** |

Deux mesures de conformité :

- Un obus normal traverse **736 px en 4,00 s ± 1 tick**, exactement la valeur relevée sur l'original.
- Le missile va exactement deux fois plus vite.

Et deux filets de sécurité :

- **Anti-tunneling** : balayage sur **360 angles** contre un mur d'une seule tuile d'épaisseur, au **double** de la vitesse maximale du jeu — pour garder de la marge quand #10 permettra de l'augmenter. Aucune traversée.
- **Déterminisme** : 900 ticks de trajectoire avec rebonds multiples, empreintes identiques.

Le test bout-en-bout du ricochet vise **strictement à la verticale, calculé depuis la position réelle du tank** : viser « en bas à droite » à vue de nez faisait dériver l'obus vers la paroi d'un couloir large d'une tuile, les deux murs étaient touchés à une frame d'intervalle, et la fenêtre d'observation du rebond durait un seul pas de simulation. L'observation se fait dans la page, une fois par frame — un sondage depuis Node manquait l'instant.
