### PR TITLE
Mines, explosions en chaîne et destruction du terrain

### DIFF
--- a/e2e/mines.spec.ts
+++ b/e2e/mines.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test';
+
+// La déclaration de `window.__tanks` vit dans src/client/debug-bridge.ts.
+import '../src/client/debug-bridge';
+
+type Page = import('@playwright/test').Page;
+
+/** Résumé de l'état du monde utile aux mines. */
+async function survey(page: Page) {
+  return page.evaluate(() => {
+    const world = window.__tanks!.world;
+    return {
+      tankX: world.tanks[0]!.x,
+      tankAlive: world.tanks[0]!.alive,
+      mines: world.mines.length,
+      explosions: world.explosions.length,
+      // TileKind.Destructible === 2
+      destructibles: world.grid.tiles.filter((tile) => tile === 2).length,
+      gridVersion: world.grid.version,
+    };
+  });
+}
+
+async function hold(page: Page, keys: string[], milliseconds: number): Promise<void> {
+  for (const key of keys) await page.keyboard.down(key);
+  await page.waitForTimeout(milliseconds);
+  for (const key of keys) await page.keyboard.up(key);
+}
+
+test('un clic droit bref pose bien une mine', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  expect((await survey(page)).mines).toBe(0);
+
+  // Un clic dure une dizaine de millisecondes, la simulation n'échantillonne
+  // que toutes les seize. Sans verrouillage des appuis brefs dans
+  // l'échantillonneur, cette pression tomberait entre deux pas et serait
+  // perdue — un geste sur deux resterait sans effet.
+  await page.mouse.click(300, 300, { button: 'right' });
+  await page.waitForTimeout(100);
+
+  expect((await survey(page)).mines).toBe(1);
+});
+
+test('la mine perce la barrière cassable et ouvre le passage', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  const start = await survey(page);
+
+  // La barrière cassable est à cinq tuiles à gauche du point de départ : le
+  // tank vient s'y plaquer et ne peut pas aller plus loin.
+  await hold(page, ['KeyA'], 2200);
+  const blocked = await survey(page);
+  expect(blocked.tankX).toBeLessThan(start.tankX);
+
+  // Poser la mine puis se replier hors du rayon.
+  await page.mouse.click(300, 300, { button: 'right' });
+  await page.waitForTimeout(100);
+  expect((await survey(page)).mines).toBe(1);
+
+  await hold(page, ['KeyD'], 1200);
+
+  // Attendre la détonation.
+  let detonated = false;
+  for (let attempt = 0; attempt < 80 && !detonated; attempt++) {
+    await page.waitForTimeout(60);
+    detonated = (await survey(page)).mines === 0;
+  }
+  expect(detonated).toBe(true);
+
+  const after = await survey(page);
+
+  // Un bloc cassable en moins, et la grille signale son changement pour que le
+  // cache de terrain du rendu se reconstruise.
+  expect(after.destructibles).toBeLessThan(start.destructibles);
+  expect(after.gridVersion).toBeGreaterThan(start.gridVersion);
+
+  // Le tank s'était éloigné : il a survécu à sa propre mine.
+  expect(after.tankAlive).toBe(true);
+
+  // Et le passage est désormais franchissable.
+  await hold(page, ['KeyA'], 2600);
+  const through = await survey(page);
+  expect(through.tankX).toBeLessThan(blocked.tankX - 0.5);
+});
+
+test('rester sur sa propre mine est fatal', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  await page.mouse.click(300, 300, { button: 'right' });
+  await page.waitForTimeout(100);
+  expect((await survey(page)).mines).toBe(1);
+
+  // On ne bouge pas. Dans l'original comme ici, la mine ne fait pas de
+  // distinction entre son poseur et les autres.
+  let killed = false;
+  for (let attempt = 0; attempt < 100 && !killed; attempt++) {
+    await page.waitForTimeout(60);
+    killed = !(await survey(page)).tankAlive;
+  }
+
+  expect(killed).toBe(true);
+});

--- a/src/client/input/sampler.ts
+++ b/src/client/input/sampler.ts
@@ -18,6 +18,18 @@ export type PointerToWorld = (clientX: number, clientY: number) => { x: number; 
 
 export class InputSampler {
   readonly #active = new Set<GameAction>();
+
+  /**
+   * Actions pressées depuis le dernier échantillonnage, même déjà relâchées.
+   *
+   * La simulation n'échantillonne que soixante fois par seconde. Sans ce
+   * verrouillage, un appui bref — un clic dure une dizaine de millisecondes —
+   * pourrait commencer et finir entre deux pas, et disparaître purement et
+   * simplement. Un tir ou une mine perdus sans raison visible sont exactement
+   * le genre de chose qui rend un jeu frustrant.
+   */
+  readonly #pressedSinceSample = new Set<GameAction>();
+
   readonly #target: HTMLElement;
   readonly #pointerToWorld: PointerToWorld;
   readonly #disposers: Array<() => void> = [];
@@ -47,24 +59,39 @@ export class InputSampler {
     this.#originY = y;
   }
 
-  /** Construit l'intention correspondant à l'état courant des entrées. */
+  /**
+   * Construit l'intention correspondant aux entrées depuis le dernier appel.
+   *
+   * Consomme le verrou d'appuis brefs : chaque pression est donc rapportée
+   * exactement une fois au minimum, même si elle a été relâchée entre-temps.
+   */
   sample(): InputCommand {
+    const held = (action: GameAction): boolean =>
+      this.#active.has(action) || this.#pressedSinceSample.has(action);
+
+    // Les directions ne sont pas verrouillées : un déplacement est un état
+    // maintenu, pas un évènement. Le verrouiller ferait avancer le tank d'un
+    // pas fantôme après le relâchement.
     const moveX = (this.#active.has('right') ? 1 : 0) - (this.#active.has('left') ? 1 : 0);
     const moveY = (this.#active.has('down') ? 1 : 0) - (this.#active.has('up') ? 1 : 0);
 
-    return {
+    const command: InputCommand = {
       moveX,
       moveY,
       aim: Math.atan2(this.#aimY - this.#originY, this.#aimX - this.#originX),
-      fire: this.#active.has('fire'),
-      mine: this.#active.has('mine'),
+      fire: held('fire'),
+      mine: held('mine'),
     };
+
+    this.#pressedSinceSample.clear();
+    return command;
   }
 
   dispose(): void {
     for (const dispose of this.#disposers) dispose();
     this.#disposers.length = 0;
     this.#active.clear();
+    this.#pressedSinceSample.clear();
   }
 
   /* ── Câblage ─────────────────────────────────────────────────────────── */
@@ -75,7 +102,7 @@ export class InputSampler {
       if (!action) return;
       // Sinon la barre d'espace ferait défiler la page sous le jeu.
       event.preventDefault();
-      this.#active.add(action);
+      this.#press(action);
     });
 
     this.#listen(window, 'keyup', (event) => {
@@ -96,7 +123,7 @@ export class InputSampler {
 
     this.#listen(this.#target, 'pointerdown', (event) => {
       const action = MOUSE_BINDINGS[(event as PointerEvent).button];
-      if (action) this.#active.add(action);
+      if (action) this.#press(action);
     });
 
     // Sur `window` et non sur la cible : un bouton relâché en dehors du canevas
@@ -108,6 +135,12 @@ export class InputSampler {
 
     // Le clic droit sert à poser une mine : pas de menu contextuel.
     this.#listen(this.#target, 'contextmenu', (event) => event.preventDefault());
+  }
+
+  /** Enregistre une pression : état maintenu, et verrou pour l'échantillon à venir. */
+  #press(action: GameAction): void {
+    this.#active.add(action);
+    this.#pressedSinceSample.add(action);
   }
 
   #listen(target: EventTarget, type: string, handler: (event: Event) => void): void {

--- a/src/client/local/sandbox.ts
+++ b/src/client/local/sandbox.ts
@@ -2,30 +2,36 @@
  * Terrain d'essai.
  *
  * Provisoire : les 20 vraies missions arrivent en #12, portées depuis les
- * tracés de `legacy/src/level.ts`. Celui-ci existe pour éprouver le pilotage —
- * il réunit volontairement les situations qui mettent le mouvement en défaut :
- * couloirs d'une tuile, angles rentrants, diagonales à longer, culs-de-sac, et
- * un trou qu'on doit pouvoir contourner.
+ * tracés de `legacy/src/level.ts`. Celui-ci existe pour éprouver les
+ * mécaniques, et réunit volontairement les situations qui les mettent en
+ * défaut :
+ *
+ *   - couloirs d'une tuile de large, angles rentrants et culs-de-sac, pour le
+ *     glissement et l'étanchéité des murs ;
+ *   - un puits de trous, que les tanks contournent mais que les obus survolent ;
+ *   - quatre **barrières cassables** placées en travers de couloirs, dont une à
+ *     cinq tuiles du point de départ : le seul moyen de passer est d'y poser
+ *     une mine.
  */
 
 import type { World } from '@core/state';
-import { allocateEntityId, createWorld } from '@core/world';
+import { createTank, createWorld } from '@core/world';
 import { parseMission } from '@shared/missions/parse';
 
 const SANDBOX = `
 #########################
 #.......................#
 #.###.#####.#####.#####.#
-#.#...#...........#...#.#
-#.#.###.#######.###.#.#.#
-#...#...#XXXXX#...#...#.#
-#.###.#.#HHHHH#.#.#.###.#
-#.....#.#HHHHH#.#.#.....#
-#.###.#.#XXXXX#.#.#.###.#
-#.#...#.........#...#..1#
-#.#.#########.#########.#
-#...#.................#.#
-#.#########.#########.#.#
+#.#.......X.......X...#.#
+#.#.#####.#.#####.#.#.#.#
+#...#...#.#.#HHH#.#.#...#
+#.###.#.#.#.#HHH#.#.#.#.#
+#.....#.#.#.#HHH#.#...#.#
+#.#####.#.#.#####.#####.#
+#.......#.X.......X....1#
+#.#####.#.#######.#####.#
+#.....#.#.........#.....#
+#.###.#.###########.###.#
 #.......................#
 #########################
 `;
@@ -42,20 +48,12 @@ export function createSandbox(): { world: World; playerTankId: number } {
   });
   world.grid = mission.grid;
 
-  const playerTankId = allocateEntityId(world);
-  world.tanks.push({
-    id: playerTankId,
+  const player = createTank(world, {
     color: 'player',
     playerId: 'local',
     x: spawn.x,
     y: spawn.y,
-    bodyAngle: 0,
-    turretAngle: 0,
-    alive: true,
-    activeShells: 0,
-    activeMines: 0,
-    reloadTicks: 0,
   });
 
-  return { world, playerTankId };
+  return { world, playerTankId: player.id };
 }

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -68,11 +68,13 @@ function sampleRates(nowMs: number): void {
 function drawOverlay(ctx: CanvasRenderingContext2D): void {
   const tank = game.playerTank;
   const shells = tank ? `${tank.activeShells}/${TUNING.tank.maxActiveShells}` : '—';
+  const mines = tank ? `${tank.activeMines}/${TUNING.tank.maxActiveMines}` : '—';
+  const status = tank?.alive === false ? '  — DÉTRUIT' : '';
 
   const lines = [
     `pas/s ${rates.ticksPerSecond} (attendu ${TICK_RATE})   frames/s ${rates.framesPerSecond}`,
-    `obus en vol ${shells}`,
-    'ZQSD / WASD / flèches — souris pour viser, clic pour tirer',
+    `obus ${shells}   mines ${mines}${status}`,
+    'ZQSD / WASD / flèches — souris pour viser, clic gauche tirer, clic droit miner',
   ];
 
   // En bas de l'image : le bandeau ne doit pas masquer le terrain de jeu.

--- a/src/client/render/canvas2d/Canvas2DRenderer.ts
+++ b/src/client/render/canvas2d/Canvas2DRenderer.ts
@@ -10,9 +10,15 @@ import { TileKind } from '@core/state';
 import type { Grid } from '@core/state';
 import { TILE_SIZE_PX, TUNING } from '@core/tuning';
 import { tileAt } from '@core/grid';
-import { BLOCKS, BOARD, SHELL, TANK_COLORS, darken, lighten } from '../palette';
+import { BLAST, BLOCKS, BOARD, SHELL, TANK_COLORS, darken, lighten } from '../palette';
 import type { Renderer } from '../Renderer';
-import type { RenderSnapshot, ShellView, TankView } from '../snapshots';
+import type {
+  ExplosionView,
+  MineView,
+  RenderSnapshot,
+  ShellView,
+  TankView,
+} from '../snapshots';
 
 /** Décalage vertical des faces de blocs, qui simule leur épaisseur. */
 const BLOCK_RELIEF_PX = 5;
@@ -24,6 +30,7 @@ export class Canvas2DRenderer implements Renderer {
   /** Cache du terrain. Reconstruit seulement quand la grille change. */
   #terrain: HTMLCanvasElement | null = null;
   #terrainStale = true;
+  #terrainVersion = -1;
 
   constructor(canvas: HTMLCanvasElement) {
     const ctx = canvas.getContext('2d');
@@ -58,8 +65,18 @@ export class Canvas2DRenderer implements Renderer {
   }
 
   draw(grid: Grid, view: RenderSnapshot): void {
-    if (this.#terrainStale) this.#buildTerrain(grid);
+    // Le cache se reconstruit sur changement de version plutôt que sur appel
+    // explicite : personne ne peut oublier de signaler une destruction de bloc.
+    if (this.#terrainStale || grid.version !== this.#terrainVersion) {
+      this.#buildTerrain(grid);
+    }
     if (this.#terrain) this.#ctx.drawImage(this.#terrain, 0, 0);
+
+    // Les mines au sol, sous tout le reste : un tank posé dessus doit rester
+    // visible.
+    for (const mine of view.mines) {
+      this.#drawMine(mine);
+    }
 
     for (const tank of view.tanks) {
       if (tank.alive) this.#drawTank(tank);
@@ -68,6 +85,11 @@ export class Canvas2DRenderer implements Renderer {
     // Les obus par-dessus les tanks : c'est ce qu'on doit suivre des yeux.
     for (const shell of view.shells) {
       this.#drawShell(shell);
+    }
+
+    // Et les explosions au-dessus de tout.
+    for (const explosion of view.explosions) {
+      this.#drawExplosion(explosion);
     }
   }
 
@@ -108,6 +130,7 @@ export class Canvas2DRenderer implements Renderer {
 
     this.#terrain = canvas;
     this.#terrainStale = false;
+    this.#terrainVersion = grid.version;
   }
 
   #drawFloor(ctx: CanvasRenderingContext2D, grid: Grid): void {
@@ -280,6 +303,67 @@ export class Canvas2DRenderer implements Renderer {
       ctx.arc(-radius * 0.35, -radius * 0.35, radius * 0.55, 0, Math.PI * 2);
       ctx.fill();
     }
+
+    ctx.restore();
+  }
+
+  /* ── Mines et explosions ─────────────────────────────────────────────── */
+
+  #drawMine(mine: MineView): void {
+    const ctx = this.#ctx;
+    const radius = TUNING.mine.radiusTiles * TILE_SIZE_PX;
+
+    ctx.save();
+    ctx.translate(mine.x * TILE_SIZE_PX, mine.y * TILE_SIZE_PX);
+
+    ctx.fillStyle = BOARD.shadow;
+    ctx.beginPath();
+    ctx.ellipse(1, 2, radius, radius * 0.85, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = BLAST.mineBody;
+    ctx.beginPath();
+    ctx.arc(0, 0, radius, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.strokeStyle = BLAST.mineRim;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // Voyant : c'est le seul indice donné au joueur pour juger s'il a encore le
+    // temps de passer. Il ne clignote que plus vite, jamais différemment.
+    if (mine.blinkOn) {
+      ctx.fillStyle = mine.urgency > 0.6 ? BLAST.mineLightUrgent : BLAST.mineLightIdle;
+      ctx.beginPath();
+      ctx.arc(0, 0, radius * 0.45, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    ctx.restore();
+  }
+
+  #drawExplosion(explosion: ExplosionView): void {
+    const ctx = this.#ctx;
+
+    // La boule croît vite puis s'estompe : une racine carrée donne cette
+    // détente franche au début, sans le côté mou d'une progression linéaire.
+    const growth = Math.sqrt(Math.min(1, explosion.progress * 1.6));
+    const radius = explosion.radius * TILE_SIZE_PX * (0.45 + 0.55 * growth);
+    const fade = 1 - explosion.progress;
+
+    ctx.save();
+    ctx.translate(explosion.x * TILE_SIZE_PX, explosion.y * TILE_SIZE_PX);
+    ctx.globalAlpha = fade;
+
+    const gradient = ctx.createRadialGradient(0, 0, 0, 0, 0, radius);
+    gradient.addColorStop(0, BLAST.fireCore);
+    gradient.addColorStop(0.55, BLAST.fireEdge);
+    gradient.addColorStop(1, BLAST.smoke);
+
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(0, 0, radius, 0, Math.PI * 2);
+    ctx.fill();
 
     ctx.restore();
   }

--- a/src/client/render/palette.ts
+++ b/src/client/render/palette.ts
@@ -48,6 +48,19 @@ export const SHELL = {
   fastTip: '#e8623a',
 };
 
+/** Mines et explosions. */
+export const BLAST = {
+  mineBody: '#4a4038',
+  mineRim: '#241e19',
+  /** Voyant au repos, puis à l'approche de la détonation. */
+  mineLightIdle: '#8a5a2a',
+  mineLightUrgent: '#ff5a2a',
+  /** Coeur puis bord de la boule de feu. */
+  fireCore: '#fff2c4',
+  fireEdge: '#e0561f',
+  smoke: 'rgba(60, 45, 35, 0.35)',
+};
+
 /** Couleur principale de chaque type de tank. */
 export const TANK_COLORS: Record<TankColor, string> = {
   player: '#4a90d9',

--- a/src/client/render/snapshots.ts
+++ b/src/client/render/snapshots.ts
@@ -15,6 +15,8 @@
 
 import { lerp, lerpAngle } from '@core/math';
 import type { ShellKind, TankColor, World } from '@core/state';
+import { TICK_RATE } from '@core/tick';
+import { TUNING } from '@core/tuning';
 
 export interface TankView {
   id: number;
@@ -35,10 +37,41 @@ export interface ShellView {
   heading: number;
 }
 
+export interface MineView {
+  id: number;
+  x: number;
+  y: number;
+  /** Avancement de la mèche, de 0 (fraîchement posée) à 1 (imminente). */
+  urgency: number;
+  /** Voyant allumé ou éteint. Le clignotement s'accélère avec l'urgence. */
+  blinkOn: boolean;
+}
+
+export interface ExplosionView {
+  id: number;
+  x: number;
+  y: number;
+  radius: number;
+  /** Avancement de l'animation, de 0 (naissance) à 1 (fin). */
+  progress: number;
+}
+
 export interface RenderSnapshot {
   tick: number;
   tanks: TankView[];
   shells: ShellView[];
+  mines: MineView[];
+  explosions: ExplosionView[];
+}
+
+/**
+ * Période de clignotement d'une mine, en ticks, selon l'urgence.
+ *
+ * Elle se resserre à mesure que la mèche se consume : c'est le seul indice
+ * donné au joueur pour savoir s'il a encore le temps de passer.
+ */
+function blinkPeriod(urgency: number): number {
+  return Math.max(3, Math.round(24 - 21 * urgency));
 }
 
 /** Extrait d'un monde ce qui est nécessaire au rendu. */
@@ -60,6 +93,29 @@ export function captureSnapshot(world: World): RenderSnapshot {
       x: shell.x,
       y: shell.y,
       heading: Math.atan2(shell.vy, shell.vx),
+    })),
+
+    mines: world.mines.map((mine) => {
+      // L'urgence se déduit du réglage courant de la mèche : une mine posée
+      // reste lisible même si la durée a changé entre-temps.
+      const total = Math.max(1, Math.round(TUNING.mine.fuseSeconds * TICK_RATE));
+      const urgency = Math.min(1, Math.max(0, 1 - mine.fuseTicks / total));
+
+      return {
+        id: mine.id,
+        x: mine.x,
+        y: mine.y,
+        urgency,
+        blinkOn: Math.floor(mine.fuseTicks / blinkPeriod(urgency)) % 2 === 0,
+      };
+    }),
+
+    explosions: world.explosions.map((explosion) => ({
+      id: explosion.id,
+      x: explosion.x,
+      y: explosion.y,
+      radius: explosion.radius,
+      progress: 1 - explosion.ticksLeft / Math.max(1, explosion.totalTicks),
     })),
   };
 }
@@ -108,5 +164,11 @@ export function interpolateSnapshots(
         heading: lerpAngle(before.heading, shell.heading, alpha),
       };
     }),
+
+    // Mines et explosions ne sont pas interpolées : les mines ne bougent pas,
+    // et lisser l'avancement d'une explosion qui dure vingt pas n'apporterait
+    // rien de perceptible.
+    mines: current.mines,
+    explosions: current.explosions,
   };
 }

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -45,6 +45,17 @@ export interface Grid {
   width: number;
   height: number;
   tiles: TileKind[];
+
+  /**
+   * Incrémenté à chaque modification du terrain.
+   *
+   * Le rendu met la grille en cache dans un canevas hors écran — elle ne change
+   * qu'à la destruction d'un bloc, alors que le reste est redessiné jusqu'à
+   * 240 fois par seconde. Ce compteur lui dit quand reconstruire, sans avoir à
+   * comparer les tuiles une à une. Il fait partie de l'état, donc il traverse
+   * le réseau et informe aussi les clients distants (#13).
+   */
+  version: number;
 }
 
 /* ── Tanks ────────────────────────────────────────────────────────────────── */
@@ -93,6 +104,16 @@ export interface Tank {
 
   /** Ticks restants avant de pouvoir tirer à nouveau. */
   reloadTicks: number;
+
+  /**
+   * Ticks restants avant de pouvoir reposer une mine.
+   *
+   * Sans ce délai, maintenir la touche enfoncée viderait le stock de mines en
+   * deux pas consécutifs. L'original se joue par appuis distincts ; un délai
+   * court reproduit ce rythme sans exiger de détecter les fronts d'appui, ce
+   * qui obligerait à mémoriser l'entrée précédente dans l'état.
+   */
+  mineReloadTicks: number;
 }
 
 /* ── Projectiles ──────────────────────────────────────────────────────────── */
@@ -162,6 +183,14 @@ export interface Explosion {
   radius: number;
   /** Ticks restants d'affichage. Les dégâts sont appliqués au tick d'apparition. */
   ticksLeft: number;
+  /**
+   * Durée totale, conservée pour que le rendu puisse en déduire l'avancement.
+   *
+   * Portée par l'entité plutôt que relue dans les réglages : une explosion en
+   * cours doit finir son animation même si la durée est modifiée en direct par
+   * le panneau de calibration (#10).
+   */
+  totalTicks: number;
 }
 
 /* ── Monde ────────────────────────────────────────────────────────────────── */

--- a/src/core/systems/mines.ts
+++ b/src/core/systems/mines.ts
@@ -1,0 +1,222 @@
+/**
+ * Mines, explosions et destruction du terrain.
+ *
+ * Les mines n'existaient nulle part dans le projet — ni dans la copie locale,
+ * ni sur `origin/main`. C'est pourtant le seul moyen d'ouvrir un passage dans
+ * un bloc cassable, donc un pilier du level design de l'original : plusieurs
+ * missions ne sont franchissables qu'en perçant un mur.
+ *
+ * Le terrain distinguait déjà cassable et incassable côté `origin/main`, et
+ * exposait un `destroyWallsInRadius()` que personne n'appelait. C'est ce
+ * chaînon manquant.
+ */
+
+import { setTile, tileAt } from '../grid.js';
+import { TileKind } from '../state.js';
+import { secondsToTicks } from '../tick.js';
+import { TUNING } from '../tuning.js';
+import { allocateEntityId } from '../world.js';
+import type { EntityId, InputCommand, Mine, Tank, World } from '../state.js';
+
+/**
+ * Pose une mine, si le quota et le délai le permettent.
+ *
+ * @returns la mine posée, ou `null` si la pose a été refusée
+ */
+export function layMine(world: World, tank: Tank): Mine | null {
+  if (!tank.alive) return null;
+  if (tank.mineReloadTicks > 0) return null;
+  if (tank.activeMines >= TUNING.tank.maxActiveMines) return null;
+
+  const mine: Mine = {
+    id: allocateEntityId(world),
+    ownerId: tank.id,
+    x: tank.x,
+    y: tank.y,
+    fuseTicks: secondsToTicks(TUNING.mine.fuseSeconds),
+  };
+
+  world.mines.push(mine);
+  tank.activeMines++;
+  tank.mineReloadTicks = secondsToTicks(TUNING.mine.cooldownSeconds);
+
+  return mine;
+}
+
+/** Traite les intentions de pose du pas courant. */
+export function updateMineLaying(
+  world: World,
+  intents: ReadonlyMap<EntityId, InputCommand>,
+): void {
+  for (const tank of world.tanks) {
+    const input = intents.get(tank.id);
+    if (input?.mine) layMine(world, tank);
+  }
+}
+
+/** Distance du centre d'un cercle au point le plus proche d'une boîte. */
+function circleReachesBox(
+  circleX: number,
+  circleY: number,
+  radius: number,
+  boxX: number,
+  boxY: number,
+  boxHalf: number,
+): boolean {
+  const nearestX = Math.max(boxX - boxHalf, Math.min(circleX, boxX + boxHalf));
+  const nearestY = Math.max(boxY - boxHalf, Math.min(circleY, boxY + boxHalf));
+
+  const dx = circleX - nearestX;
+  const dy = circleY - nearestY;
+
+  return dx * dx + dy * dy < radius * radius;
+}
+
+/**
+ * Détruit les blocs cassables dans le rayon du souffle.
+ *
+ * Le rayon se mesure jusqu'au **centre** de chaque tuile : une tuile n'est
+ * emportée que si le souffle l'atteint franchement, pas si elle l'effleure par
+ * un coin. Sans ça, une explosion ouvrirait des brèches en escalier aux angles.
+ */
+function destroyTerrain(world: World, centerX: number, centerY: number, radius: number): void {
+  const minTileX = Math.max(0, Math.floor(centerX - radius));
+  const maxTileX = Math.min(world.grid.width - 1, Math.floor(centerX + radius));
+  const minTileY = Math.max(0, Math.floor(centerY - radius));
+  const maxTileY = Math.min(world.grid.height - 1, Math.floor(centerY + radius));
+
+  let changed = false;
+
+  for (let tileY = minTileY; tileY <= maxTileY; tileY++) {
+    for (let tileX = minTileX; tileX <= maxTileX; tileX++) {
+      if (tileAt(world.grid, tileX, tileY) !== TileKind.Destructible) continue;
+
+      const dx = tileX + 0.5 - centerX;
+      const dy = tileY + 0.5 - centerY;
+      if (dx * dx + dy * dy > radius * radius) continue;
+
+      setTile(world.grid, tileX, tileY, TileKind.Empty);
+      changed = true;
+    }
+  }
+
+  // Signale au rendu de reconstruire son cache de terrain, et informe les
+  // clients distants (#13) que la grille a changé.
+  if (changed) world.grid.version++;
+}
+
+/**
+ * Fait exploser une mine : terrain, tanks, obus, et mines voisines.
+ *
+ * @param chain file des mines à faire détoner ensuite
+ */
+function detonate(
+  world: World,
+  mine: Mine,
+  doomed: Set<EntityId>,
+  chain: Mine[],
+): void {
+  const radius = TUNING.mine.blastRadiusTiles;
+
+  const duration = secondsToTicks(TUNING.mine.blastDurationSeconds);
+  world.explosions.push({
+    id: allocateEntityId(world),
+    x: mine.x,
+    y: mine.y,
+    radius,
+    ticksLeft: duration,
+    totalTicks: duration,
+  });
+
+  destroyTerrain(world, mine.x, mine.y, radius);
+
+  // Tanks — y compris celui qui a posé la mine. Rester à côté de sa propre
+  // mine est mortel, exactement comme dans l'original.
+  const tankHalf = TUNING.tank.sizeTiles / 2;
+  for (const tank of world.tanks) {
+    if (!tank.alive) continue;
+    if (circleReachesBox(mine.x, mine.y, radius, tank.x, tank.y, tankHalf)) {
+      tank.alive = false;
+    }
+  }
+
+  // Obus pris dans le souffle.
+  for (const shell of world.shells) {
+    if (doomed.has(shell.id)) continue;
+    const dx = shell.x - mine.x;
+    const dy = shell.y - mine.y;
+    if (dx * dx + dy * dy < radius * radius) doomed.add(shell.id);
+  }
+
+  // Mines voisines : réaction en chaîne. Chaque mine ne détone qu'une fois,
+  // puisqu'elle est marquée avant d'être empilée — c'est ce qui garantit la
+  // terminaison de la cascade.
+  for (const other of world.mines) {
+    if (other.id === mine.id || doomed.has(other.id)) continue;
+    const dx = other.x - mine.x;
+    const dy = other.y - mine.y;
+    if (dx * dx + dy * dy < radius * radius) {
+      doomed.add(other.id);
+      chain.push(other);
+    }
+  }
+}
+
+/**
+ * Décompte les mèches et traite les détonations du pas.
+ *
+ * @param doomedShells obus déjà condamnés ce pas, pour ne pas les recompter
+ */
+export function updateMines(world: World, doomed: Set<EntityId>): void {
+  const chain: Mine[] = [];
+  const shellRadius = TUNING.shell.radiusTiles;
+  const mineRadius = TUNING.mine.radiusTiles;
+
+  for (const mine of world.mines) {
+    if (doomed.has(mine.id)) continue;
+
+    if (mine.fuseTicks > 0) mine.fuseTicks--;
+
+    // Une mine touchée par un obus explose immédiatement, sans attendre sa
+    // mèche : c'est ce qui permet de désamorcer un piège à distance.
+    let struck = false;
+    for (const shell of world.shells) {
+      if (doomed.has(shell.id)) continue;
+      const dx = shell.x - mine.x;
+      const dy = shell.y - mine.y;
+      const contact = shellRadius + mineRadius;
+      if (dx * dx + dy * dy < contact * contact) {
+        doomed.add(shell.id);
+        struck = true;
+        break;
+      }
+    }
+
+    if (mine.fuseTicks <= 0 || struck) {
+      doomed.add(mine.id);
+      chain.push(mine);
+    }
+  }
+
+  // Cascade. La file ne peut que se vider : une mine est marquée condamnée
+  // avant d'y entrer, donc jamais empilée deux fois.
+  while (chain.length > 0) {
+    detonate(world, chain.shift()!, doomed, chain);
+  }
+}
+
+/** Retire les mines détonées et rend son quota à chaque poseur. */
+export function removeDoomedMines(world: World, doomed: ReadonlySet<EntityId>): void {
+  if (doomed.size === 0) return;
+
+  let kept = 0;
+  for (const mine of world.mines) {
+    if (doomed.has(mine.id)) {
+      const owner = world.tanks.find((tank) => tank.id === mine.ownerId);
+      if (owner && owner.activeMines > 0) owner.activeMines--;
+      continue;
+    }
+    world.mines[kept++] = mine;
+  }
+  world.mines.length = kept;
+}

--- a/src/core/tick.ts
+++ b/src/core/tick.ts
@@ -15,6 +15,7 @@
  */
 
 import { resolveShellShellHits, resolveShellTankHits } from './systems/damage.js';
+import { removeDoomedMines, updateMineLaying, updateMines } from './systems/mines.js';
 import { updateMovement } from './systems/movement.js';
 import { removeDoomedShells, updateFiring, updateShells } from './systems/shells.js';
 import type { EntityId, InputCommand, World } from './state.js';
@@ -64,8 +65,10 @@ export function tick(world: World, inputs: TickInputs): void {
   // 2. Déplacement des tanks : résolution X puis Y, glissement le long des murs.
   updateMovement(world, intents);
 
-  // 3. Tirs, après le déplacement : l'obus part de la position finale du tank.
+  // 3. Actions, après le déplacement : l'obus part de la position finale du
+  //    tank, et la mine se pose là où il se trouve réellement.
   updateFiring(world, intents);
+  updateMineLaying(world, intents);
 
   // Entités condamnées durant ce pas. Volontairement local et non stocké dans
   // le monde : retirer une entité en cours de parcours décalerait les indices
@@ -76,30 +79,36 @@ export function tick(world: World, inputs: TickInputs): void {
   // 4. Trajectoire des obus : balayage continu et rebonds.
   updateShells(world, doomed);
 
-  // 5. Mèches et détonations → #9 (mines, explosions, destruction du terrain)
+  // 5. Compteurs, avant les détonations : une explosion créée à ce pas doit
+  //    vivre sa durée complète, pas être amputée d'un tick dès sa naissance.
+  advanceTimers(world);
 
-  // 6. Impacts. Obus contre obus d'abord : deux obus qui se croisent
+  // 6. Mèches, détonations, cascades et destruction du terrain.
+  updateMines(world, doomed);
+
+  // 7. Impacts. Obus contre obus d'abord : deux obus qui se croisent
   //    s'annulent, même si l'un d'eux atteignait un tank au même pas.
   resolveShellShellHits(world, doomed);
   resolveShellTankHits(world, doomed);
 
-  advanceTimers(world);
-
-  // 7. Compactage : les entités marquées disparaissent ici, et seulement ici.
+  // 8. Compactage : les entités marquées disparaissent ici, et seulement ici.
   removeDoomedShells(world, doomed);
+  removeDoomedMines(world, doomed);
   removeExpiredExplosions(world);
 
   world.tick++;
 }
 
-/** Décrémente tous les compteurs temporels d'un pas. */
+/**
+ * Décrémente les compteurs temporels d'un pas.
+ *
+ * Les mèches de mines ne sont pas traitées ici mais dans `updateMines`, où le
+ * décompte et la détonation qu'il déclenche restent au même endroit.
+ */
 function advanceTimers(world: World): void {
   for (const tank of world.tanks) {
     if (tank.reloadTicks > 0) tank.reloadTicks--;
-  }
-
-  for (const mine of world.mines) {
-    if (mine.fuseTicks > 0) mine.fuseTicks--;
+    if (tank.mineReloadTicks > 0) tank.mineReloadTicks--;
   }
 
   for (const explosion of world.explosions) {

--- a/src/core/tuning.ts
+++ b/src/core/tuning.ts
@@ -102,6 +102,10 @@ export interface Tuning {
     blastRadiusTiles: number;
     /** Durée d'affichage de l'explosion, en secondes. */
     blastDurationSeconds: number;
+    /** Délai minimal entre deux poses, en secondes. */
+    cooldownSeconds: number;
+    /** Rayon de collision d'une mine, en tuiles. Sert aux impacts d'obus. */
+    radiusTiles: number;
   };
 }
 
@@ -132,7 +136,11 @@ export const TUNING: Tuning = {
   },
   mine: {
     fuseSeconds: 3,
+    // Deux tuiles : de quoi ouvrir un passage franc dans un mur cassable, ce
+    // qui est la raison d'être des mines dans le level design de l'original.
     blastRadiusTiles: 2,
     blastDurationSeconds: 0.35,
+    cooldownSeconds: 0.5,
+    radiusTiles: 0.35,
   },
 };

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -8,7 +8,7 @@
 
 import { createRng } from './rng.js';
 import { TileKind } from './state.js';
-import type { EntityId, Grid, World } from './state.js';
+import type { EntityId, Grid, Tank, TankColor, World } from './state.js';
 
 /** Paramètres de création d'un monde vide. */
 export interface WorldOptions {
@@ -33,7 +33,7 @@ export function createGrid(width: number, height: number): Grid {
     tiles[y * width + (width - 1)] = TileKind.Indestructible;
   }
 
-  return { width, height, tiles };
+  return { width, height, tiles, version: 0 };
 }
 
 /** Crée un monde vide, prêt à être peuplé par le chargeur de mission (#12). */
@@ -60,6 +60,49 @@ export function createWorld({ width, height, seed }: WorldOptions): World {
  */
 export function allocateEntityId(world: World): EntityId {
   return world.nextEntityId++;
+}
+
+/** Paramètres de création d'un tank. Tout le reste part d'un état neutre. */
+export interface TankOptions {
+  color: TankColor;
+  /** Position du centre, en tuiles. */
+  x: number;
+  y: number;
+  /** Joueur qui le pilote, ou `null` pour un tank de l'IA. */
+  playerId?: string | null;
+  /** Orientation initiale du châssis et de la tourelle, en radians. */
+  angle?: number;
+}
+
+/**
+ * Crée un tank et l'ajoute au monde.
+ *
+ * Fabrique unique et volontaire : les compteurs (`activeShells`,
+ * `reloadTicks`, …) sont des détails d'implémentation des systèmes, et les
+ * recopier à chaque point de création — chargement de mission, test, bac à
+ * sable — garantirait qu'un oubli passe inaperçu le jour où le tank gagne un
+ * champ.
+ */
+export function createTank(world: World, options: TankOptions): Tank {
+  const angle = options.angle ?? 0;
+
+  const tank: Tank = {
+    id: allocateEntityId(world),
+    color: options.color,
+    playerId: options.playerId ?? null,
+    x: options.x,
+    y: options.y,
+    bodyAngle: angle,
+    turretAngle: angle,
+    alive: true,
+    activeShells: 0,
+    activeMines: 0,
+    reloadTicks: 0,
+    mineReloadTicks: 0,
+  };
+
+  world.tanks.push(tank);
+  return tank;
 }
 
 /**

--- a/src/shared/missions/parse.ts
+++ b/src/shared/missions/parse.ts
@@ -139,5 +139,5 @@ export function parseMission(source: string): ParsedMission {
     .sort(([left], [right]) => left - right)
     .map(([, spawn]) => spawn);
 
-  return { grid: { width, height, tiles }, playerSpawns, enemySpawns };
+  return { grid: { width, height, tiles, version: 0 }, playerSpawns, enemySpawns };
 }

--- a/tests/determinism.test.ts
+++ b/tests/determinism.test.ts
@@ -5,7 +5,7 @@ import { TileKind } from '../src/core/state.js';
 import type { InputCommand, World } from '../src/core/state.js';
 import { DT, TICK_RATE, secondsToTicks, tick } from '../src/core/tick.js';
 import type { TickInputs } from '../src/core/tick.js';
-import { allocateEntityId, cloneWorld, createWorld, hashWorld } from '../src/core/world.js';
+import { allocateEntityId, cloneWorld, createTank, createWorld, hashWorld } from '../src/core/world.js';
 
 /**
  * Le déterminisme n'est pas un détail de propreté : c'est ce qui permet au
@@ -21,19 +21,8 @@ import { allocateEntityId, cloneWorld, createWorld, hashWorld } from '../src/cor
 function makeWorld(seed = 12_345): World {
   const world = createWorld({ width: 20, height: 15, seed });
 
-  world.tanks.push({
-    id: allocateEntityId(world),
-    color: 'player',
-    playerId: 'p1',
-    x: 3.5,
-    y: 3.5,
-    bodyAngle: 0,
-    turretAngle: 0,
-    alive: true,
-    activeShells: 0,
-    activeMines: 0,
-    reloadTicks: 7,
-  });
+  const tank = createTank(world, { color: 'player', playerId: 'p1', x: 3.5, y: 3.5 });
+  tank.reloadTicks = 7;
 
   world.mines.push({
     id: allocateEntityId(world),
@@ -49,6 +38,7 @@ function makeWorld(seed = 12_345): World {
     y: 8,
     radius: 2,
     ticksLeft: 3,
+    totalTicks: 3,
   });
 
   return world;
@@ -138,22 +128,16 @@ describe('empreinte du monde', () => {
   test("l'empreinte ne dépend pas de l'ordre d'insertion des propriétés", () => {
     const world = makeWorld();
 
-    // Même contenu, propriétés énumérées dans un autre ordre.
+    // Même contenu, propriétés énumérées dans l'ordre inverse. Construit par
+    // réflexion plutôt qu'à la main : le test resterait sinon à recopier à
+    // chaque champ ajouté au tank, et cesserait silencieusement de couvrir les
+    // nouveaux.
     const reordered = cloneWorld(world);
     const tank = reordered.tanks[0]!;
-    reordered.tanks[0] = {
-      reloadTicks: tank.reloadTicks,
-      activeMines: tank.activeMines,
-      activeShells: tank.activeShells,
-      alive: tank.alive,
-      turretAngle: tank.turretAngle,
-      bodyAngle: tank.bodyAngle,
-      y: tank.y,
-      x: tank.x,
-      playerId: tank.playerId,
-      color: tank.color,
-      id: tank.id,
-    };
+    const reversed = Object.fromEntries(
+      Object.entries(tank).reverse(),
+    ) as unknown as typeof tank;
+    reordered.tanks[0] = reversed;
 
     expect(hashWorld(reordered)).toBe(hashWorld(world));
   });
@@ -256,6 +240,7 @@ describe('compteurs temporels', () => {
       y: 1,
       radius: 2,
       ticksLeft: 10,
+      totalTicks: 10,
     });
     expect(world.explosions).toHaveLength(2);
 

--- a/tests/mines.test.ts
+++ b/tests/mines.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, test } from 'bun:test';
+
+import { setTile, tileAt } from '../src/core/grid.js';
+import { TileKind } from '../src/core/state.js';
+import type { InputCommand, Mine, Tank, World } from '../src/core/state.js';
+import { TICK_RATE, secondsToTicks, tick } from '../src/core/tick.js';
+import type { TickInputs } from '../src/core/tick.js';
+import { layMine } from '../src/core/systems/mines.js';
+import { shellSpeed } from '../src/core/systems/shells.js';
+import { TUNING } from '../src/core/tuning.js';
+import { allocateEntityId, createTank, createWorld, hashWorld } from '../src/core/world.js';
+
+/**
+ * Les mines n'existaient nulle part dans le projet, alors qu'elles sont le seul
+ * moyen d'ouvrir un passage dans un bloc cassable — donc la clé de plusieurs
+ * missions de l'original.
+ */
+
+function openWorld(width = 30, height = 20): World {
+  return createWorld({ width, height, seed: 1 });
+}
+
+function addTank(world: World, x: number, y: number): Tank {
+  return createTank(world, { color: 'player', playerId: 'p1', x, y });
+}
+
+/** Pose une mine directement, sans passer par un tank ni par les quotas. */
+function addMine(world: World, x: number, y: number, fuseTicks = 30): Mine {
+  const mine: Mine = { id: allocateEntityId(world), ownerId: -1, x, y, fuseTicks };
+  world.mines.push(mine);
+  return mine;
+}
+
+function input(overrides: Partial<InputCommand> = {}): InputCommand {
+  return { moveX: 0, moveY: 0, aim: 0, fire: false, mine: false, ...overrides };
+}
+
+function advance(world: World, ticks: number, inputs: TickInputs = []): void {
+  for (let i = 0; i < ticks; i++) tick(world, inputs);
+}
+
+const FUSE_TICKS = secondsToTicks(TUNING.mine.fuseSeconds);
+
+describe('pose', () => {
+  test('la touche pose une mine à la position du tank', () => {
+    const world = openWorld();
+    const tank = addTank(world, 10.25, 7.75);
+
+    advance(world, 1, [[tank.id, input({ mine: true })]]);
+
+    expect(world.mines).toHaveLength(1);
+    expect(world.mines[0]).toMatchObject({ x: 10.25, y: 7.75, ownerId: tank.id });
+  });
+
+  test('le quota de mines simultanées est respecté', () => {
+    const world = openWorld();
+    const tank = addTank(world, 10, 10);
+
+    for (let i = 0; i < TUNING.tank.maxActiveMines + 3; i++) {
+      tank.mineReloadTicks = 0;
+      layMine(world, tank);
+    }
+
+    expect(world.mines).toHaveLength(TUNING.tank.maxActiveMines);
+    expect(tank.activeMines).toBe(TUNING.tank.maxActiveMines);
+  });
+
+  test('maintenir la touche ne vide pas le stock en deux pas', () => {
+    // Sans délai de pose, une touche maintenue déclencherait une pose par tick.
+    const world = openWorld();
+    const tank = addTank(world, 10, 10);
+
+    advance(world, 3, [[tank.id, input({ mine: true })]]);
+
+    expect(world.mines).toHaveLength(1);
+  });
+
+  test('le délai écoulé, une deuxième mine peut être posée', () => {
+    const world = openWorld();
+    const tank = addTank(world, 10, 10);
+
+    const held: TickInputs = [[tank.id, input({ mine: true })]];
+    advance(world, 1, held);
+    advance(world, secondsToTicks(TUNING.mine.cooldownSeconds) + 1, held);
+
+    expect(world.mines).toHaveLength(2);
+  });
+
+  test('le quota est rendu après la détonation', () => {
+    const world = openWorld();
+    const tank = addTank(world, 10, 10);
+    layMine(world, tank);
+    expect(tank.activeMines).toBe(1);
+
+    advance(world, FUSE_TICKS + 2);
+
+    expect(world.mines).toHaveLength(0);
+    expect(tank.activeMines).toBe(0);
+  });
+
+  test('un tank mort ne pose pas de mine', () => {
+    const world = openWorld();
+    const tank = addTank(world, 10, 10);
+    tank.alive = false;
+
+    expect(layMine(world, tank)).toBeNull();
+  });
+});
+
+describe('mèche', () => {
+  test('la mine explose à la fin de sa mèche, pas avant', () => {
+    const world = openWorld();
+    addMine(world, 10, 10, FUSE_TICKS);
+
+    advance(world, FUSE_TICKS - 1);
+    expect(world.mines).toHaveLength(1);
+
+    advance(world, 2);
+    expect(world.mines).toHaveLength(0);
+  });
+
+  test('la durée correspond au réglage', () => {
+    const world = openWorld();
+    const tank = addTank(world, 10, 10);
+    layMine(world, tank);
+
+    let ticks = 0;
+    while (world.mines.length > 0 && ticks < 1000) {
+      advance(world, 1);
+      ticks++;
+    }
+
+    expect(ticks / TICK_RATE).toBeCloseTo(TUNING.mine.fuseSeconds, 1);
+  });
+
+  test('une explosion apparaît et vit sa durée complète', () => {
+    const world = openWorld();
+    addMine(world, 10, 10, 1);
+
+    advance(world, 1);
+    expect(world.explosions).toHaveLength(1);
+
+    const duration = secondsToTicks(TUNING.mine.blastDurationSeconds);
+    advance(world, duration - 1);
+    expect(world.explosions).toHaveLength(1);
+
+    advance(world, 2);
+    expect(world.explosions).toHaveLength(0);
+  });
+});
+
+describe('destruction du terrain', () => {
+  test('les blocs cassables du rayon disparaissent, les incassables restent', () => {
+    const world = openWorld();
+
+    // Un mur mixte traversant le rayon de l'explosion.
+    for (let y = 8; y <= 12; y++) setTile(world.grid, 10, y, TileKind.Destructible);
+    setTile(world.grid, 11, 10, TileKind.Indestructible);
+
+    addMine(world, 10.5, 10.5, 1);
+    advance(world, 2);
+
+    expect(tileAt(world.grid, 10, 10)).toBe(TileKind.Empty);
+    expect(tileAt(world.grid, 10, 9)).toBe(TileKind.Empty);
+    expect(tileAt(world.grid, 10, 11)).toBe(TileKind.Empty);
+    // L'incassable est à portée, et pourtant intact.
+    expect(tileAt(world.grid, 11, 10)).toBe(TileKind.Indestructible);
+  });
+
+  test('les blocs hors du rayon sont épargnés', () => {
+    const world = openWorld();
+    const farAway = Math.ceil(TUNING.mine.blastRadiusTiles) + 3;
+    setTile(world.grid, 10 + farAway, 10, TileKind.Destructible);
+
+    addMine(world, 10.5, 10.5, 1);
+    advance(world, 2);
+
+    expect(tileAt(world.grid, 10 + farAway, 10)).toBe(TileKind.Destructible);
+  });
+
+  test('la version de la grille change, pour invalider le cache de rendu', () => {
+    const world = openWorld();
+    setTile(world.grid, 10, 10, TileKind.Destructible);
+    const before = world.grid.version;
+
+    addMine(world, 10.5, 10.5, 1);
+    advance(world, 2);
+
+    expect(world.grid.version).toBeGreaterThan(before);
+  });
+
+  test('une explosion sans rien à détruire ne change pas la version', () => {
+    const world = openWorld();
+    const before = world.grid.version;
+
+    addMine(world, 10.5, 10.5, 1);
+    advance(world, 2);
+
+    expect(world.grid.version).toBe(before);
+  });
+
+  test('la brèche ouverte laisse passer un obus, qui n\'y rebondit plus', () => {
+    const world = openWorld(30, 12);
+    for (let y = 1; y < 11; y++) setTile(world.grid, 15, y, TileKind.Destructible);
+
+    // On perce le mur à hauteur de la trajectoire.
+    addMine(world, 15.5, 6.5, 1);
+    advance(world, 3);
+    expect(tileAt(world.grid, 15, 6)).toBe(TileKind.Empty);
+
+    world.shells.push({
+      id: allocateEntityId(world),
+      ownerId: -1,
+      kind: 'normal',
+      x: 5,
+      y: 6.5,
+      vx: shellSpeed('normal'),
+      vy: 0,
+      bouncesLeft: 1,
+      armed: true,
+    });
+
+    advance(world, 150);
+
+    const shell = world.shells[0];
+    expect(shell).toBeDefined();
+    expect(shell!.x).toBeGreaterThan(16);
+    expect(shell!.vx).toBeGreaterThan(0);
+  });
+
+  test('la brèche laisse passer un tank', () => {
+    const world = openWorld(30, 12);
+    for (let y = 1; y < 11; y++) setTile(world.grid, 15, y, TileKind.Destructible);
+
+    const tank = addTank(world, 13, 6.5);
+    addMine(world, 15.5, 6.5, 1);
+    advance(world, 3);
+
+    advance(world, 200, [[tank.id, input({ moveX: 1 })]]);
+
+    expect(tank.x).toBeGreaterThan(16);
+  });
+});
+
+describe('effets sur les entités', () => {
+  test('le poseur meurt s\'il reste sur sa propre mine', () => {
+    const world = openWorld();
+    const tank = addTank(world, 10, 10);
+    layMine(world, tank);
+
+    advance(world, FUSE_TICKS + 2);
+
+    expect(tank.alive).toBe(false);
+  });
+
+  test('s\'éloigner à temps sauve le poseur', () => {
+    const world = openWorld(40, 20);
+    const tank = addTank(world, 10, 10);
+    layMine(world, tank);
+
+    advance(world, FUSE_TICKS + 2, [[tank.id, input({ moveX: 1 })]]);
+
+    expect(tank.alive).toBe(true);
+    expect(tank.x).toBeGreaterThan(10 + TUNING.mine.blastRadiusTiles);
+  });
+
+  test('un tank hors du rayon survit', () => {
+    const world = openWorld();
+    const survivor = addTank(world, 10 + TUNING.mine.blastRadiusTiles + 2, 10);
+
+    addMine(world, 10, 10, 1);
+    advance(world, 2);
+
+    expect(survivor.alive).toBe(true);
+  });
+
+  test('un obus pris dans le souffle est détruit', () => {
+    const world = openWorld();
+    world.shells.push({
+      id: allocateEntityId(world),
+      ownerId: -1,
+      kind: 'normal',
+      x: 10.5,
+      y: 10,
+      vx: 0,
+      vy: 0,
+      bouncesLeft: 5,
+      armed: true,
+    });
+
+    addMine(world, 10, 10, 1);
+    advance(world, 2);
+
+    expect(world.shells).toHaveLength(0);
+  });
+
+  test('un obus qui touche une mine la fait détoner immédiatement', () => {
+    // Permet de désamorcer un piège à distance, sans attendre la mèche.
+    const world = openWorld(40, 20);
+    const mine = addMine(world, 20, 10, 9999);
+
+    world.shells.push({
+      id: allocateEntityId(world),
+      ownerId: -1,
+      kind: 'normal',
+      x: 15,
+      y: 10,
+      vx: shellSpeed('normal'),
+      vy: 0,
+      bouncesLeft: 1,
+      armed: true,
+    });
+
+    advance(world, 120);
+
+    expect(world.mines.find((m) => m.id === mine.id)).toBeUndefined();
+    expect(world.shells).toHaveLength(0);
+  });
+});
+
+describe('réactions en chaîne', () => {
+  test('une mine en amorce toutes les autres à portée', () => {
+    const world = openWorld(40, 20);
+    const step = TUNING.mine.blastRadiusTiles * 0.8;
+
+    addMine(world, 10, 10, 1);
+    addMine(world, 10 + step, 10, 9999);
+    addMine(world, 10 + step * 2, 10, 9999);
+    addMine(world, 10 + step * 3, 10, 9999);
+
+    advance(world, 2);
+
+    // La cascade se propage entièrement dans le même pas.
+    expect(world.mines).toHaveLength(0);
+    expect(world.explosions).toHaveLength(4);
+  });
+
+  test('la chaîne s\'arrête là où l\'espacement dépasse le rayon', () => {
+    const world = openWorld(60, 20);
+    const near = TUNING.mine.blastRadiusTiles * 0.8;
+    const far = TUNING.mine.blastRadiusTiles * 3;
+
+    addMine(world, 10, 10, 1);
+    addMine(world, 10 + near, 10, 9999);
+    const isolated = addMine(world, 10 + near + far, 10, 9999);
+
+    advance(world, 2);
+
+    expect(world.mines).toHaveLength(1);
+    expect(world.mines[0]!.id).toBe(isolated.id);
+  });
+
+  test('deux mines qui s\'amorcent mutuellement ne bouclent pas', () => {
+    // Chaque mine est marquée avant d'entrer dans la file, donc elle ne peut
+    // pas y être empilée deux fois — c'est ce qui garantit la terminaison.
+    const world = openWorld();
+    addMine(world, 10, 10, 1);
+    addMine(world, 10.2, 10, 1);
+
+    advance(world, 2);
+
+    expect(world.mines).toHaveLength(0);
+    expect(world.explosions).toHaveLength(2);
+  });
+
+  test('une chaîne perce un mur sur toute sa longueur', () => {
+    const world = openWorld(40, 20);
+    for (let y = 4; y <= 16; y++) setTile(world.grid, 20, y, TileKind.Destructible);
+
+    const step = TUNING.mine.blastRadiusTiles * 0.8;
+    addMine(world, 20.5, 7, 1);
+    addMine(world, 20.5, 7 + step, 9999);
+    addMine(world, 20.5, 7 + step * 2, 9999);
+
+    advance(world, 2);
+
+    let opened = 0;
+    for (let y = 4; y <= 16; y++) {
+      if (tileAt(world.grid, 20, y) === TileKind.Empty) opened++;
+    }
+
+    // Bien plus large que ce qu'une mine seule aurait ouvert.
+    expect(opened).toBeGreaterThan(TUNING.mine.blastRadiusTiles * 2);
+  });
+});
+
+describe('déterminisme', () => {
+  test('une cascade rejouée produit la même empreinte', () => {
+    const build = (): World => {
+      const world = openWorld(40, 20);
+      for (let y = 4; y <= 16; y++) setTile(world.grid, 20, y, TileKind.Destructible);
+      for (let x = 14; x <= 26; x++) setTile(world.grid, x, 12, TileKind.Destructible);
+
+      const step = TUNING.mine.blastRadiusTiles * 0.7;
+      addMine(world, 20.5, 8, 20);
+      addMine(world, 20.5, 8 + step, 9999);
+      addMine(world, 20.5 + step, 8 + step * 2, 9999);
+      addTank(world, 25, 15);
+      return world;
+    };
+
+    const a = build();
+    const b = build();
+    advance(a, 300);
+    advance(b, 300);
+
+    expect(hashWorld(a)).toBe(hashWorld(b));
+  });
+});

--- a/tests/movement.test.ts
+++ b/tests/movement.test.ts
@@ -7,7 +7,7 @@ import type { InputCommand, Tank, World } from '../src/core/state.js';
 import { TICK_RATE, tick } from '../src/core/tick.js';
 import type { TickInputs } from '../src/core/tick.js';
 import { REFERENCE_MEASUREMENTS, TILE_SIZE_PX, TUNING } from '../src/core/tuning.js';
-import { allocateEntityId, createWorld } from '../src/core/world.js';
+import { createTank, createWorld } from '../src/core/world.js';
 
 /** Monde ouvert, sans obstacle intérieur, pour mesurer sans interférence. */
 function openWorld(width = 40, height = 20): World {
@@ -15,21 +15,7 @@ function openWorld(width = 40, height = 20): World {
 }
 
 function addTank(world: World, x: number, y: number): Tank {
-  const tank: Tank = {
-    id: allocateEntityId(world),
-    color: 'player',
-    playerId: 'p1',
-    x,
-    y,
-    bodyAngle: 0,
-    turretAngle: 0,
-    alive: true,
-    activeShells: 0,
-    activeMines: 0,
-    reloadTicks: 0,
-  };
-  world.tanks.push(tank);
-  return tank;
+  return createTank(world, { color: 'player', playerId: 'p1', x, y });
 }
 
 function input(overrides: Partial<InputCommand> = {}): InputCommand {

--- a/tests/shells.test.ts
+++ b/tests/shells.test.ts
@@ -7,27 +7,15 @@ import { TICK_RATE, tick } from '../src/core/tick.js';
 import type { TickInputs } from '../src/core/tick.js';
 import { fireShell, shellSpeed } from '../src/core/systems/shells.js';
 import { REFERENCE_MEASUREMENTS, TILE_SIZE_PX, TUNING } from '../src/core/tuning.js';
-import { allocateEntityId, createWorld, hashWorld } from '../src/core/world.js';
+import { allocateEntityId, createTank, createWorld, hashWorld } from '../src/core/world.js';
 
 function openWorld(width = 40, height = 30): World {
   return createWorld({ width, height, seed: 1 });
 }
 
 function addTank(world: World, x: number, y: number, turretAngle = 0): Tank {
-  const tank: Tank = {
-    id: allocateEntityId(world),
-    color: 'player',
-    playerId: null,
-    x,
-    y,
-    bodyAngle: 0,
-    turretAngle,
-    alive: true,
-    activeShells: 0,
-    activeMines: 0,
-    reloadTicks: 0,
-  };
-  world.tanks.push(tank);
+  const tank = createTank(world, { color: 'player', x, y, angle: turretAngle });
+  tank.bodyAngle = 0;
   return tank;
 }
 

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -4,7 +4,7 @@ import { normalizeAngle } from '../src/core/math.js';
 import { captureSnapshot, interpolateSnapshots } from '../src/client/render/snapshots.js';
 import type { RenderSnapshot } from '../src/client/render/snapshots.js';
 import type { World } from '../src/core/state.js';
-import { allocateEntityId, createWorld } from '../src/core/world.js';
+import { createTank, createWorld } from '../src/core/world.js';
 
 /**
  * L'interpolation existe parce que la simulation avance à 60 Hz alors que
@@ -14,19 +14,9 @@ import { allocateEntityId, createWorld } from '../src/core/world.js';
 
 function worldWithTank(x: number, y: number, angles = { body: 0, turret: 0 }): World {
   const world = createWorld({ width: 10, height: 10, seed: 1 });
-  world.tanks.push({
-    id: allocateEntityId(world),
-    color: 'player',
-    playerId: 'p1',
-    x,
-    y,
-    bodyAngle: angles.body,
-    turretAngle: angles.turret,
-    alive: true,
-    activeShells: 0,
-    activeMines: 0,
-    reloadTicks: 0,
-  });
+  const tank = createTank(world, { color: 'player', playerId: 'p1', x, y });
+  tank.bodyAngle = angles.body;
+  tank.turretAngle = angles.turret;
   return world;
 }
 
@@ -87,7 +77,7 @@ describe('interpolation', () => {
   test('une entité qui vient d\'apparaître est prise telle quelle', () => {
     // La faire glisser depuis une position d'origine inventée produirait un
     // fantôme traversant l'écran au moment du spawn.
-    const empty: RenderSnapshot = { tick: 0, tanks: [], shells: [] };
+    const empty: RenderSnapshot = { tick: 0, tanks: [], shells: [], mines: [], explosions: [] };
     const view = interpolateSnapshots(empty, current, 0.5).tanks[0]!;
 
     expect(view.x).toBe(4);


### PR DESCRIPTION
Closes #9

Les mines n'existaient **nulle part** dans le projet — ni dans la copie locale, ni sur `origin/main`. C'est pourtant le seul moyen d'ouvrir un passage dans un bloc cassable, donc la clé de plusieurs missions de l'original.

Le terrain distinguait déjà cassable et incassable côté `origin/main`, et exposait un `destroyWallsInRadius()` que personne n'appelait. C'était le chaînon manquant.

## Ce qu'une explosion fait

- **Tue tout tank dans son rayon, y compris son poseur.** Rester à côté de sa propre mine est fatal, exactement comme dans l'original.
- **Détruit les blocs cassables**, laisse les incassables intacts.
- **Détruit les obus** pris dans le souffle.
- **Amorce les mines voisines** → réaction en chaîne.
- Un **obus qui touche une mine** la fait détoner immédiatement, ce qui permet de désamorcer un piège à distance.

La cascade est traitée par file d'attente : chaque mine est marquée condamnée **avant** d'y entrer, donc jamais empilée deux fois. Deux mines qui s'amorcent mutuellement ne peuvent pas boucler — un test le vérifie.

Le rayon de destruction se mesure jusqu'au **centre** de chaque tuile : une tuile n'est emportée que si le souffle l'atteint franchement, pas si elle l'effleure par un coin. Sans ça, les brèches s'ouvriraient en escalier aux angles.

## Invalidation du cache de terrain

La grille porte un compteur de `version`, incrémenté à chaque modification. Le rendu reconstruit son cache quand il change, **plutôt que sur un appel explicite** que quelqu'un finirait par oublier. Ce compteur fait partie de l'état, donc il traversera le réseau et informera aussi les clients distants (#13).

## Deux corrections trouvées en chemin

### Les appuis brefs étaient perdus

Le bug s'est manifesté à la première tentative de pose par clic : `mines: 0`, rien ne se passait.

Un clic dure une dizaine de millisecondes ; la simulation n'échantillonne les entrées que toutes les seize. La pression commençait et finissait **entre deux pas** et disparaissait purement et simplement. Un tir ou une mine perdus sans raison visible sont exactement ce qui rend un jeu frustrant.

L'échantillonneur verrouille désormais toute pression jusqu'à ce qu'au moins un échantillon l'ait rapportée. Les directions, elles, ne sont **pas** verrouillées : un déplacement est un état maintenu, pas un évènement, et le verrouiller ferait avancer le tank d'un pas fantôme après le relâchement.

### La construction des tanks était dupliquée

Elle était recopiée dans le bac à sable et quatre fichiers de test. Ajouter un champ au tank cassait les six endroits, et il suffisait d'en oublier un pour qu'un test cesse silencieusement de couvrir le nouveau champ. Une fabrique unique `createTank()` remplace tout ça.

Dans la foulée, le test « l'empreinte ne dépend pas de l'ordre des propriétés » construit désormais son objet par réflexion plutôt qu'à la main, pour la même raison.

### Le bac à sable était mal tracé

Les blocs cassables y étaient enfermés dans une zone inatteignable — impossible d'éprouver la mécanique. Quatre barrières bloquent maintenant de vrais couloirs, dont une à **cinq tuiles du point de départ**.

## Vérification

| Commande | Résultat |
|---|---|
| `bun test ./tests` | **133 passés**, 0 échec |
| `bunx tsc --noEmit` | aucune erreur |
| `bunx playwright test` | **12 passés** |

Cycle complet observé de bout en bout dans le navigateur :

```
depart           tank x 23.50   mines 0   blocs cassables 4   version grille 0
contre barriere  tank x 19.39   mines 0   blocs cassables 4   version grille 0
mine posee       tank x 19.39   mines 1   blocs cassables 4   version grille 0
explosion        tank x 23.44   mines 0   blocs cassables 3   version grille 1
apres            tank x 23.44   mines 0   blocs cassables 3   version grille 1
```

Le tank vient se plaquer contre la barrière (`x = 19.39`, soit la face du bloc plus son demi-côté), pose une mine, se replie, et le bloc disparaît. Le test bout-en-bout vérifie ensuite que le passage est **effectivement franchissable**.

Les tests unitaires couvrent : quotas et délai de pose, durée de mèche, sélectivité cassable/incassable, épargne hors rayon, survie du poseur qui s'éloigne, mort de celui qui reste, obus détruit par le souffle, obus qui détone une mine, cascade complète, arrêt de la cascade au-delà du rayon, absence de boucle sur amorçage mutuel, percement d'un mur sur toute sa longueur, franchissement de la brèche par un obus **et** par un tank, et déterminisme d'une cascade rejouée.
