### PR TITLE
IA : profils des 9 couleurs et visée avec rebonds

### DIFF
--- a/e2e/ai.spec.ts
+++ b/e2e/ai.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test';
+
+// La déclaration de `window.__tanks` vit dans src/client/debug-bridge.ts.
+import '../src/client/debug-bridge';
+
+type Page = import('@playwright/test').Page;
+
+async function survey(page: Page) {
+  return page.evaluate(() => {
+    const world = window.__tanks!.world;
+    return world.tanks.map((tank) => ({
+      color: tank.color,
+      x: tank.x,
+      y: tank.y,
+      alive: tank.alive,
+      hasSolution: tank.ai?.solutionAngle !== null && tank.ai !== null,
+      isAi: tank.playerId === null,
+    }));
+  });
+}
+
+test('les ennemis sont présents et se comportent selon leur couleur', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  const start = await survey(page);
+  const enemies = start.filter((tank) => tank.isAi);
+
+  expect(enemies.length).toBeGreaterThanOrEqual(4);
+  // Chaque couleur présente est distincte : le bac à sable montre des
+  // comportements différents, pas cinq fois le même tank.
+  expect(new Set(enemies.map((tank) => tank.color)).size).toBe(enemies.length);
+
+  await page.waitForTimeout(3000);
+  const later = await survey(page);
+
+  const moved = (color: string): number => {
+    const before = start.find((tank) => tank.color === color)!;
+    const after = later.find((tank) => tank.color === color)!;
+    return Math.hypot(after.x - before.x, after.y - before.y);
+  };
+
+  // Le brun et le vert sont des tourelles fixes.
+  expect(moved('brown')).toBeCloseTo(0, 6);
+  expect(moved('green')).toBeCloseTo(0, 6);
+
+  // Le violet traque : il parcourt une vraie distance.
+  expect(moved('purple')).toBeGreaterThan(1);
+});
+
+test('un ennemi finit par ouvrir le feu sur le joueur', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  // Observation frame par frame dans la page : un obus traverse l'arène en
+  // quelques secondes et un sondage depuis Node manquerait la fenêtre.
+  const observed = await page.evaluate(async () => {
+    const startMs = performance.now();
+    let sawEnemyShell = false;
+    let sawSolution = false;
+
+    while (performance.now() - startMs < 8000 && !sawEnemyShell) {
+      const world = window.__tanks!.world;
+
+      for (const tank of world.tanks) {
+        if (tank.playerId === null && tank.ai?.solutionAngle != null) sawSolution = true;
+      }
+
+      for (const shell of world.shells) {
+        const owner = world.tanks.find((tank) => tank.id === shell.ownerId);
+        if (owner && owner.playerId === null) sawEnemyShell = true;
+      }
+
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    }
+
+    return { sawEnemyShell, sawSolution };
+  });
+
+  expect(observed.sawSolution).toBe(true);
+  expect(observed.sawEnemyShell).toBe(true);
+});
+
+test('les tanks ne se superposent jamais', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(300);
+
+  // Deux tanks empilés se comportent comme un seul et sont illisibles à
+  // l'écran. Ils sont des obstacles les uns pour les autres.
+  const overlaps = await page.evaluate(async () => {
+    const startMs = performance.now();
+    let worst = Number.POSITIVE_INFINITY;
+
+    while (performance.now() - startMs < 5000) {
+      const tanks = window.__tanks!.world.tanks.filter((tank) => tank.alive);
+
+      for (let i = 0; i < tanks.length; i++) {
+        for (let j = i + 1; j < tanks.length; j++) {
+          const a = tanks[i]!;
+          const b = tanks[j]!;
+          worst = Math.min(worst, Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y)));
+        }
+      }
+
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    }
+
+    return worst;
+  });
+
+  // La séparation la plus faible observée doit rester au moins de la taille
+  // d'un tank, à la tolérance de résolution près.
+  expect(overlaps).toBeGreaterThan(0.7);
+});

--- a/e2e/mines.spec.ts
+++ b/e2e/mines.spec.ts
@@ -28,7 +28,7 @@ async function hold(page: Page, keys: string[], milliseconds: number): Promise<v
 }
 
 test('un clic droit bref pose bien une mine', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?calme=1');
   await page.waitForTimeout(300);
 
   expect((await survey(page)).mines).toBe(0);
@@ -44,23 +44,24 @@ test('un clic droit bref pose bien une mine', async ({ page }) => {
 });
 
 test('la mine perce la barrière cassable et ouvre le passage', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?calme=1');
   await page.waitForTimeout(300);
 
   const start = await survey(page);
 
-  // La barrière cassable est à cinq tuiles à gauche du point de départ : le
-  // tank vient s'y plaquer et ne peut pas aller plus loin.
-  await hold(page, ['KeyA'], 2200);
+  // Une paire de blocs cassables ferme le couloir à gauche du point de départ :
+  // le tank vient s'y plaquer et ne peut pas aller plus loin.
+  await hold(page, ['KeyA'], 1500);
   const blocked = await survey(page);
   expect(blocked.tankX).toBeLessThan(start.tankX);
 
-  // Poser la mine puis se replier hors du rayon.
+  // Poser la mine, puis se replier vers le haut : le couloir est trop étroit
+  // pour sortir du rayon de souffle en reculant simplement.
   await page.mouse.click(300, 300, { button: 'right' });
   await page.waitForTimeout(100);
   expect((await survey(page)).mines).toBe(1);
 
-  await hold(page, ['KeyD'], 1200);
+  await hold(page, ['KeyW'], 1600);
 
   // Attendre la détonation.
   let detonated = false;
@@ -80,14 +81,15 @@ test('la mine perce la barrière cassable et ouvre le passage', async ({ page })
   // Le tank s'était éloigné : il a survécu à sa propre mine.
   expect(after.tankAlive).toBe(true);
 
-  // Et le passage est désormais franchissable.
-  await hold(page, ['KeyA'], 2600);
+  // Et le passage est désormais franchissable : on redescend puis on traverse.
+  await hold(page, ['KeyS'], 1600);
+  await hold(page, ['KeyA'], 2000);
   const through = await survey(page);
   expect(through.tankX).toBeLessThan(blocked.tankX - 0.5);
 });
 
 test('rester sur sa propre mine est fatal', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?calme=1');
   await page.waitForTimeout(300);
 
   await page.mouse.click(300, 300, { button: 'right' });

--- a/e2e/movement.spec.ts
+++ b/e2e/movement.spec.ts
@@ -30,7 +30,7 @@ async function hold(
 }
 
 test('le clavier déplace le tank', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?calme=1');
   await page.waitForTimeout(300);
 
   const before = await tankPosition(page);
@@ -42,24 +42,32 @@ test('le clavier déplace le tank', async ({ page }) => {
 });
 
 test('le tank longe le mur au lieu de s\'y bloquer', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?calme=1');
   await page.waitForTimeout(300);
 
-  const before = await tankPosition(page);
+  const grid = await page.evaluate(() => ({
+    width: window.__tanks!.world.grid.width,
+  }));
 
-  // Poussée en diagonale contre le mur de droite : l'axe X est bloqué, l'axe Y
-  // doit continuer. C'est le comportement que l'ancienne version n'avait pas —
-  // elle rejetait le déplacement entier et le tank se figeait contre le mur.
+  // On se plaque d'abord contre la bordure droite, pour partir d'un contact
+  // franc plutôt que d'une position quelconque.
+  await hold(page, ['KeyD'], 600);
+  const before = await tankPosition(page);
+  expect(before.x).toBeGreaterThan(grid.width - 2);
+
+  // Poussée en diagonale contre ce mur : l'axe X est bloqué, l'axe Y doit
+  // continuer. C'est le comportement que l'ancienne version n'avait pas — elle
+  // rejetait le déplacement entier et le tank se figeait contre le mur.
   await hold(page, ['KeyW', 'KeyD'], 1200);
 
   const after = await tankPosition(page);
 
-  expect(after.x).toBeCloseTo(before.x, 0);
+  expect(after.x).toBeCloseTo(before.x, 1);
   expect(after.y).toBeLessThan(before.y - 1.5);
 });
 
 test('relâcher le focus arrête le tank', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?calme=1');
   await page.waitForTimeout(300);
 
   await page.keyboard.down('KeyW');
@@ -80,7 +88,7 @@ test('relâcher le focus arrête le tank', async ({ page }) => {
 });
 
 test('la souris oriente la tourelle', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/?calme=1');
   await page.waitForTimeout(300);
 
   const box = await page.locator('#game').boundingBox();

--- a/src/client/local/sandbox.ts
+++ b/src/client/local/sandbox.ts
@@ -6,12 +6,13 @@
  * mécaniques, et réunit volontairement les situations qui les mettent en
  * défaut :
  *
- *   - couloirs d'une tuile de large, angles rentrants et culs-de-sac, pour le
- *     glissement et l'étanchéité des murs ;
+ *   - un terrain **ouvert avec des couverts épars**, et non un labyrinthe de
+ *     couloirs d'une tuile : c'est la forme des arènes de l'original, et la
+ *     seule qui laisse des lignes de tir et des angles de ricochet ;
+ *   - des passages étroits en périphérie, pour le glissement le long des murs ;
  *   - un puits de trous, que les tanks contournent mais que les obus survolent ;
- *   - quatre **barrières cassables** placées en travers de couloirs, dont une à
- *     cinq tuiles du point de départ : le seul moyen de passer est d'y poser
- *     une mine.
+ *   - un réduit en blocs cassables au centre, qui ne s'ouvre qu'à la mine ;
+ *   - quatre couleurs d'ennemis aux comportements franchement distincts.
  */
 
 import type { World } from '@core/state';
@@ -21,23 +22,39 @@ import { parseMission } from '@shared/missions/parse';
 const SANDBOX = `
 #########################
 #.......................#
-#.###.#####.#####.#####.#
-#.#.......X.......X...#.#
-#.#.#####.#.#####.#.#.#.#
-#...#...#.#.#HHH#.#.#...#
-#.###.#.#.#.#HHH#.#.#.#.#
-#.....#.#.#.#HHH#.#...#.#
-#.#####.#.#.#####.#####.#
-#.......#.X.......X....1#
-#.#####.#.#######.#####.#
-#.....#.#.........#.....#
-#.###.#.###########.###.#
+#..####....b....####....#
+#..#..#.........#..#.t..#
+#.g#..#..XXXX...#..#....#
+#.....#..X..X...#..#....#
+#........X..X......#....#
+#..###...XXXX...###.....#
+#....#..........#..#....#
+#....#....HH....#..#XX.1#
+#.a..#....HH....#..#....#
+#....####......####.....#
 #.......................#
+#...p...................#
 #########################
 `;
 
+export interface SandboxOptions {
+  /**
+   * Peupler l'arène d'ennemis.
+   *
+   * Les tests bout-en-bout qui mesurent le déplacement ou les mines les
+   * désactivent : sans ça, ils mesurent un tank qui se fait canarder pendant
+   * l'expérience, et deviennent instables pour une raison sans rapport avec ce
+   * qu'ils vérifient.
+   */
+  withEnemies?: boolean;
+}
+
 /** Construit le monde d'essai et rend l'identifiant du tank du joueur. */
-export function createSandbox(): { world: World; playerTankId: number } {
+export function createSandbox(options: SandboxOptions = {}): {
+  world: World;
+  playerTankId: number;
+} {
+  const withEnemies = options.withEnemies ?? true;
   const mission = parseMission(SANDBOX);
   const spawn = mission.playerSpawns[0]!;
 
@@ -54,6 +71,15 @@ export function createSandbox(): { world: World; playerTankId: number } {
     x: spawn.x,
     y: spawn.y,
   });
+
+  // Cinq couleurs aux comportements franchement distincts : un brun immobile et
+  // maladroit, un vert immobile mais redoutable à deux rebonds, un sarcelle aux
+  // missiles rapides, un violet qui traque, et un cendre qui garde ses distances.
+  if (withEnemies) {
+    for (const enemy of mission.enemySpawns) {
+      createTank(world, { color: enemy.color, x: enemy.x, y: enemy.y });
+    }
+  }
 
   return { world, playerTankId: player.id };
 }

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -34,7 +34,10 @@ function mountCanvas(): HTMLCanvasElement {
 const canvas = mountCanvas();
 const renderer = new Canvas2DRenderer(canvas);
 
-const { world, playerTankId } = createSandbox();
+// `?calme=1` vide l'arène de ses ennemis. Sert aux tests bout-en-bout qui
+// mesurent le déplacement ou les mines et n'ont pas à composer avec des tirs.
+const peaceful = new URLSearchParams(window.location.search).has('calme');
+const { world, playerTankId } = createSandbox({ withEnemies: !peaceful });
 const game = new LocalGame(world, playerTankId);
 
 renderer.resize(world.grid);

--- a/src/client/render/canvas2d/Canvas2DRenderer.ts
+++ b/src/client/render/canvas2d/Canvas2DRenderer.ts
@@ -79,7 +79,7 @@ export class Canvas2DRenderer implements Renderer {
     }
 
     for (const tank of view.tanks) {
-      if (tank.alive) this.#drawTank(tank);
+      if (tank.alive && tank.visible) this.#drawTank(tank);
     }
 
     // Les obus par-dessus les tanks : c'est ce qu'on doit suivre des yeux.

--- a/src/client/render/snapshots.ts
+++ b/src/client/render/snapshots.ts
@@ -15,6 +15,7 @@
 
 import { lerp, lerpAngle } from '@core/math';
 import type { ShellKind, TankColor, World } from '@core/state';
+import { profileOf } from '@core/systems/ai/profiles';
 import { TICK_RATE } from '@core/tick';
 import { TUNING } from '@core/tuning';
 
@@ -26,6 +27,14 @@ export interface TankView {
   bodyAngle: number;
   turretAngle: number;
   alive: boolean;
+  /**
+   * Le tank est-il visible ?
+   *
+   * Faux pour un tank blanc au repos. Il se révèle brièvement en tirant, ce qui
+   * laisse au joueur une chance de le localiser — sans quoi il serait
+   * impossible à combattre autrement qu'au hasard.
+   */
+  visible: boolean;
 }
 
 export interface ShellView {
@@ -86,6 +95,9 @@ export function captureSnapshot(world: World): RenderSnapshot {
       bodyAngle: tank.bodyAngle,
       turretAngle: tank.turretAngle,
       alive: tank.alive,
+      // Le rechargement en cours signale un tir tout juste parti : c'est la
+      // fenêtre pendant laquelle un tank invisible se trahit.
+      visible: !profileOf(tank.color).invisible || tank.reloadTicks > 0,
     })),
     shells: world.shells.map((shell) => ({
       id: shell.id,

--- a/src/core/grid.ts
+++ b/src/core/grid.ts
@@ -330,3 +330,90 @@ export function sweepBoxAgainstGrid(
   if (!Number.isFinite(earliest)) return null;
   return { time: earliest, normalX, normalY };
 }
+
+/* ── Lancer de rayon ──────────────────────────────────────────────────────── */
+
+/** Premier obstacle rencontré par un rayon. */
+export interface RayHit {
+  /** Distance parcourue jusqu'à l'impact, en tuiles. */
+  distance: number;
+  normalX: number;
+  normalY: number;
+}
+
+/**
+ * Premier obstacle sur le trajet d'un rayon, par parcours de grille (DDA).
+ *
+ * Ne visite que les tuiles réellement traversées, là où
+ * {@link sweepBoxAgainstGrid} examine toute la boîte englobante du déplacement.
+ * Sur un rayon de vingt tuiles en diagonale, cela fait une quarantaine de
+ * tuiles au lieu de quatre cents — ce qui rend abordable la recherche d'angle
+ * de tir de l'IA, qui en lance des centaines.
+ *
+ * Le projectile est traité comme un **point** : c'est une prédiction, et chaque
+ * profil de tank applique de toute façon son propre cône d'erreur. La physique
+ * réelle des obus, elle, reste le balayage exact de `sweepBoxAgainstGrid`.
+ *
+ * @param dirX composante X d'une direction **normalisée**
+ * @param dirY composante Y d'une direction **normalisée**
+ */
+export function raycastGrid(
+  grid: Grid,
+  originX: number,
+  originY: number,
+  dirX: number,
+  dirY: number,
+  maxDistance: number,
+  isSolid: SolidityTest,
+): RayHit | null {
+  let tileX = Math.floor(originX);
+  let tileY = Math.floor(originY);
+
+  // Origine déjà dans un mur : impact immédiat, sans normale exploitable.
+  if (isSolid(tileAt(grid, tileX, tileY))) {
+    return { distance: 0, normalX: 0, normalY: 0 };
+  }
+
+  const stepX = dirX >= 0 ? 1 : -1;
+  const stepY = dirY >= 0 ? 1 : -1;
+
+  // Distance parcourue pour franchir une tuile entière sur chaque axe.
+  const spanX = dirX === 0 ? Number.POSITIVE_INFINITY : Math.abs(1 / dirX);
+  const spanY = dirY === 0 ? Number.POSITIVE_INFINITY : Math.abs(1 / dirY);
+
+  // Distance jusqu'à la première frontière de tuile sur chaque axe.
+  let nextX =
+    dirX === 0
+      ? Number.POSITIVE_INFINITY
+      : (dirX > 0 ? tileX + 1 - originX : originX - tileX) * spanX;
+  let nextY =
+    dirY === 0
+      ? Number.POSITIVE_INFINITY
+      : (dirY > 0 ? tileY + 1 - originY : originY - tileY) * spanY;
+
+  // Garde-fou : une direction non normalisée ou dégénérée ne doit pas boucler.
+  const maxSteps = 4 * (grid.width + grid.height);
+
+  for (let step = 0; step < maxSteps; step++) {
+    let distance: number;
+    let normalX = 0;
+    let normalY = 0;
+
+    if (nextX < nextY) {
+      distance = nextX;
+      tileX += stepX;
+      nextX += spanX;
+      normalX = -stepX;
+    } else {
+      distance = nextY;
+      tileY += stepY;
+      nextY += spanY;
+      normalY = -stepY;
+    }
+
+    if (distance > maxDistance) return null;
+    if (isSolid(tileAt(grid, tileX, tileY))) return { distance, normalX, normalY };
+  }
+
+  return null;
+}

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -78,6 +78,24 @@ export type TankColor =
   | 'white'
   | 'black';
 
+/**
+ * Mémoire d'un tank piloté par l'IA.
+ *
+ * Elle vit **dans l'état du monde** et non dans une structure annexe : sans ça,
+ * un rejeu ou une réconciliation réseau repartirait avec une IA amnésique et
+ * les deux simulations divergeraient.
+ */
+export interface TankAiState {
+  /** Angle de tir retenu au dernier calcul, ou `null` si aucune solution. */
+  solutionAngle: number | null;
+  /** Ticks avant le prochain tir autorisé. */
+  fireCooldownTicks: number;
+  /** Direction suivie en patrouille, en radians. */
+  roamAngle: number;
+  /** Ticks avant de choisir une nouvelle direction de patrouille. */
+  roamTicks: number;
+}
+
 export interface Tank {
   id: EntityId;
   color: TankColor;
@@ -114,6 +132,9 @@ export interface Tank {
    * qui obligerait à mémoriser l'entrée précédente dans l'état.
    */
   mineReloadTicks: number;
+
+  /** Mémoire d'IA, ou `null` pour un tank piloté par un joueur. */
+  ai: TankAiState | null;
 }
 
 /* ── Projectiles ──────────────────────────────────────────────────────────── */

--- a/src/core/systems/ai/aiming.ts
+++ b/src/core/systems/ai/aiming.ts
@@ -1,0 +1,267 @@
+/**
+ * Visée avec rebonds.
+ *
+ * C'est **la** mécanique signature de Tanks! : un tank ennemi ne tire pas
+ * seulement quand il vous voit, il calcule une trajectoire qui vous atteint
+ * après un ou deux ricochets — donc à travers un mur.
+ *
+ * L'ancienne version ne faisait rien de tout ça : elle visait en ligne droite
+ * et ajoutait du bruit aléatoire (`targetAngle += (Math.random() - 0.5) *
+ * accuracy`). Un ennemi derrière un mur était donc totalement inoffensif, ce
+ * qui retire au jeu l'essentiel de sa tension.
+ */
+
+import { blocksShell, raycastGrid } from '../../grid.js';
+import { TAU } from '../../math.js';
+import { TUNING } from '../../tuning.js';
+import type { Grid } from '../../state.js';
+
+/** Segment de trajectoire prévue, entre deux rebonds. */
+export interface TraceSegment {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+/** Longueur maximale d'une trajectoire explorée, en tuiles. */
+const MAX_TRACE_DISTANCE = 40;
+
+/**
+ * Nombre de directions échantillonnées lors de la recherche d'un angle.
+ *
+ * 180 donne un pas de 2°, largement sous le cône d'erreur du profil le plus
+ * précis (le vert, à 0,05 rad ≈ 2,9°). Aller plus fin coûterait sans rien
+ * apporter de perceptible.
+ */
+const ANGLE_SAMPLES = 180;
+
+/**
+ * Trace la trajectoire prévue d'un obus, rebonds compris.
+ *
+ * Le projectile est traité comme un point — voir la note de `raycastGrid`.
+ */
+export function traceShellPath(
+  grid: Grid,
+  originX: number,
+  originY: number,
+  angle: number,
+  bounces: number,
+  maxDistance = MAX_TRACE_DISTANCE,
+): TraceSegment[] {
+  const segments: TraceSegment[] = [];
+
+  let x = originX;
+  let y = originY;
+  let dirX = Math.cos(angle);
+  let dirY = Math.sin(angle);
+  let budget = maxDistance;
+
+  for (let leg = 0; leg <= bounces; leg++) {
+    if (budget <= 0) break;
+
+    const hit = raycastGrid(grid, x, y, dirX, dirY, budget, blocksShell);
+    const travelled = hit ? hit.distance : budget;
+
+    const endX = x + dirX * travelled;
+    const endY = y + dirY * travelled;
+    segments.push({ x0: x, y0: y, x1: endX, y1: endY });
+
+    if (!hit) break;
+
+    budget -= travelled;
+
+    // On repart très légèrement en retrait du mur, sinon le rayon suivant
+    // repartirait depuis l'intérieur de la tuile qu'on vient de toucher.
+    const nudge = 1e-4;
+    x = endX + hit.normalX * nudge;
+    y = endY + hit.normalY * nudge;
+
+    if (hit.normalX !== 0) dirX = -dirX;
+    if (hit.normalY !== 0) dirY = -dirY;
+  }
+
+  return segments;
+}
+
+/** Distance du point (px, py) au segment, avec la distance parcourue jusqu'au projeté. */
+function distanceToSegment(
+  segment: TraceSegment,
+  px: number,
+  py: number,
+): { distance: number; travelled: number } {
+  const dx = segment.x1 - segment.x0;
+  const dy = segment.y1 - segment.y0;
+  const lengthSquared = dx * dx + dy * dy;
+
+  const t =
+    lengthSquared === 0
+      ? 0
+      : Math.max(0, Math.min(1, ((px - segment.x0) * dx + (py - segment.y0) * dy) / lengthSquared));
+
+  const nearestX = segment.x0 + dx * t;
+  const nearestY = segment.y0 + dy * t;
+
+  return {
+    distance: Math.hypot(px - nearestX, py - nearestY),
+    travelled: t * Math.sqrt(lengthSquared),
+  };
+}
+
+/**
+ * La trajectoire passe-t-elle assez près d'un point ?
+ *
+ * @param ignoreBefore distance en deçà de laquelle on ne compte pas les
+ *        passages — sert à ne pas considérer qu'un tank se touche lui-même au
+ *        moment où l'obus quitte son canon
+ * @returns la distance parcourue jusqu'au point, ou `null`
+ */
+export function pathReaches(
+  segments: readonly TraceSegment[],
+  px: number,
+  py: number,
+  tolerance: number,
+  ignoreBefore = 0,
+): number | null {
+  let travelledBefore = 0;
+
+  for (const segment of segments) {
+    const { distance, travelled } = distanceToSegment(segment, px, py);
+    const total = travelledBefore + travelled;
+
+    if (distance <= tolerance && total >= ignoreBefore) return total;
+
+    travelledBefore += Math.hypot(segment.x1 - segment.x0, segment.y1 - segment.y0);
+  }
+
+  return null;
+}
+
+/** Un tank à éviter lors de la vérification de sécurité du tir. */
+export interface AimObstacle {
+  x: number;
+  y: number;
+}
+
+export interface FiringSolutionOptions {
+  /** Rebonds que le tireur est autorisé à envisager. */
+  bounces: number;
+  /**
+   * Tanks à ne pas toucher : le tireur lui-même et ses alliés.
+   *
+   * Sans ce contrôle, les profils à deux rebonds se suicident en boucle — la
+   * trajectoire la plus courte vers une cible proche repasse très souvent par
+   * le point de départ.
+   */
+  avoid: readonly AimObstacle[];
+  /** Rayon de touche, en tuiles. */
+  hitRadius: number;
+}
+
+/**
+ * Cherche un angle de tir atteignant la cible.
+ *
+ * Procède en deux temps, parce que la ligne droite est de loin le cas le plus
+ * fréquent et coûte un seul lancer de rayon :
+ *
+ *   1. tir direct, si la cible est dégagée ;
+ *   2. sinon, balayage angulaire à la recherche d'une solution avec rebonds.
+ *
+ * Parmi les solutions trouvées, on retient **la plus courte** : c'est celle qui
+ * laisse le moins de temps à la cible pour s'écarter.
+ *
+ * @returns l'angle retenu, ou `null` si aucune trajectoire sûre n'aboutit
+ */
+export function findFiringSolution(
+  grid: Grid,
+  fromX: number,
+  fromY: number,
+  targetX: number,
+  targetY: number,
+  options: FiringSolutionOptions,
+): number | null {
+  const directAngle = Math.atan2(targetY - fromY, targetX - fromX);
+
+  if (isSolutionValid(grid, fromX, fromY, targetX, targetY, directAngle, 0, options)) {
+    return directAngle;
+  }
+
+  if (options.bounces <= 0) return null;
+
+  let bestAngle: number | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (let sample = 0; sample < ANGLE_SAMPLES; sample++) {
+    const angle = (sample / ANGLE_SAMPLES) * TAU;
+    const reach = solutionDistance(
+      grid,
+      fromX,
+      fromY,
+      targetX,
+      targetY,
+      angle,
+      options.bounces,
+      options,
+    );
+
+    if (reach !== null && reach < bestDistance) {
+      bestDistance = reach;
+      bestAngle = angle;
+    }
+  }
+
+  return bestAngle;
+}
+
+/**
+ * Distance à parcourir pour atteindre la cible par cet angle, si la trajectoire
+ * est à la fois efficace et sûre.
+ */
+function solutionDistance(
+  grid: Grid,
+  fromX: number,
+  fromY: number,
+  targetX: number,
+  targetY: number,
+  angle: number,
+  bounces: number,
+  options: FiringSolutionOptions,
+): number | null {
+  const path = traceShellPath(grid, fromX, fromY, angle, bounces);
+
+  const reach = pathReaches(path, targetX, targetY, options.hitRadius);
+  if (reach === null) return null;
+
+  // Un obus qui reviendrait sur le tireur ou sur un allié **avant** d'atteindre
+  // la cible est disqualifié. Ce qu'il fait ensuite n'a plus d'importance :
+  // il aura déjà explosé sur la cible.
+  const muzzleClearance = TUNING.tank.sizeTiles;
+  for (const obstacle of options.avoid) {
+    const friendly = pathReaches(
+      path,
+      obstacle.x,
+      obstacle.y,
+      options.hitRadius,
+      muzzleClearance,
+    );
+    if (friendly !== null && friendly < reach) return null;
+  }
+
+  return reach;
+}
+
+/** Variante booléenne, pour le cas du tir direct. */
+function isSolutionValid(
+  grid: Grid,
+  fromX: number,
+  fromY: number,
+  targetX: number,
+  targetY: number,
+  angle: number,
+  bounces: number,
+  options: FiringSolutionOptions,
+): boolean {
+  return (
+    solutionDistance(grid, fromX, fromY, targetX, targetY, angle, bounces, options) !== null
+  );
+}

--- a/src/core/systems/ai/brain.ts
+++ b/src/core/systems/ai/brain.ts
@@ -1,0 +1,208 @@
+/**
+ * Décisions des tanks pilotés par l'IA.
+ *
+ * Une seule machine à états pour les neuf couleurs, entièrement paramétrée par
+ * le profil. L'ancienne version dispersait ce comportement dans trois `switch`
+ * distincts sur le type d'IA, si bien qu'ajuster un tank obligeait à toucher
+ * trois endroits — et que les couleurs finissaient par se ressembler.
+ *
+ * L'IA produit exactement le même `InputCommand` qu'un joueur. Elle passe donc
+ * par le même chemin de simulation, subit les mêmes règles, et ne peut pas
+ * tricher : un ennemi ne peut pas se déplacer plus vite que ne l'autorise le
+ * système de mouvement, ni tirer plus souvent que son rechargement.
+ */
+
+import { blocksTank, boxOverlapsSolid } from '../../grid.js';
+import { normalizeAngle } from '../../math.js';
+import { nextFloat, nextRange } from '../../rng.js';
+import { secondsToTicks } from '../../tick.js';
+import { TUNING } from '../../tuning.js';
+import { findFiringSolution } from './aiming.js';
+import { profileOf } from './profiles.js';
+import { findEvasion } from './threat.js';
+import type { InputCommand, Tank, TankAiState, World } from '../../state.js';
+import type { TankProfile } from './profiles.js';
+
+/**
+ * Période de recalcul d'un angle de tir, en ticks.
+ *
+ * La recherche coûte des centaines de lancers de rayon : la refaire à chaque
+ * pas serait du gaspillage, la cible n'ayant pas pu se déplacer de plus d'un
+ * vingtième de tuile entre-temps. Les tanks sont **décalés** par leur
+ * identifiant pour qu'ils ne calculent jamais tous au même pas.
+ */
+const AIM_PERIOD_TICKS = 12;
+
+/** Écart de visée toléré avant de tirer, en radians. */
+const AIM_TOLERANCE_RADIANS = 0.08;
+
+/** État d'IA neutre, attribué à tout tank non piloté par un joueur. */
+export function createAiState(): TankAiState {
+  return { solutionAngle: null, fireCooldownTicks: 0, roamAngle: 0, roamTicks: 0 };
+}
+
+/** Le tank que l'IA cherche à atteindre : le joueur vivant le plus proche. */
+function findTarget(world: World, tank: Tank, profile: TankProfile): Tank | null {
+  let best: Tank | null = null;
+  let bestDistance = profile.detectionRangeTiles;
+
+  for (const candidate of world.tanks) {
+    if (candidate.id === tank.id || !candidate.alive) continue;
+    // Les tanks de l'IA ne se battent pas entre eux.
+    if (candidate.playerId === null) continue;
+
+    const distance = Math.hypot(candidate.x - tank.x, candidate.y - tank.y);
+    if (distance <= bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+
+  return best;
+}
+
+/** Direction de déplacement voulue, avant prise en compte des obstacles. */
+function desiredHeading(
+  world: World,
+  tank: Tank,
+  ai: TankAiState,
+  profile: TankProfile,
+  target: Tank | null,
+): { x: number; y: number } {
+  if (profile.speedMultiplier === 0 || profile.movement === 'hold') {
+    return { x: 0, y: 0 };
+  }
+
+  const roam = (): { x: number; y: number } => ({
+    x: Math.cos(ai.roamAngle),
+    y: Math.sin(ai.roamAngle),
+  });
+
+  if (!target) return roam();
+
+  const toTargetX = target.x - tank.x;
+  const toTargetY = target.y - tank.y;
+  const distance = Math.hypot(toTargetX, toTargetY);
+  if (distance === 0) return roam();
+
+  const towards = { x: toTargetX / distance, y: toTargetY / distance };
+  const away = { x: -towards.x, y: -towards.y };
+
+  switch (profile.movement) {
+    case 'keepAway':
+      // Ne recule que si la cible est trop près ; sinon continue sa patrouille,
+      // sans quoi il resterait figé à la bonne distance comme une statue.
+      return distance < profile.preferredRangeTiles ? away : roam();
+
+    case 'hunt':
+      return distance > profile.preferredRangeTiles ? towards : roam();
+
+    case 'erratic':
+      // Alterne approche et errance selon la direction de patrouille courante,
+      // ce qui donne son allure imprévisible au tank jaune.
+      return Math.cos(ai.roamAngle) > 0 ? towards : roam();
+
+    case 'patrol':
+    default:
+      return roam();
+  }
+}
+
+/**
+ * Renouvelle la direction de patrouille quand son minuteur expire, ou quand la
+ * direction courante mène droit dans un mur.
+ */
+function updateRoaming(world: World, tank: Tank, ai: TankAiState): void {
+  const half = TUNING.tank.sizeTiles / 2;
+  const probe = TUNING.tank.sizeTiles;
+
+  const blocked = boxOverlapsSolid(
+    world.grid,
+    tank.x + Math.cos(ai.roamAngle) * probe,
+    tank.y + Math.sin(ai.roamAngle) * probe,
+    half,
+    blocksTank,
+  );
+
+  if (ai.roamTicks > 0 && !blocked) {
+    ai.roamTicks--;
+    return;
+  }
+
+  ai.roamAngle = nextRange(world.rng, 0, Math.PI * 2);
+  ai.roamTicks = Math.round(nextRange(world.rng, 30, 120));
+}
+
+/** Construit l'intention d'un tank de l'IA pour ce pas. */
+export function decideAiInput(world: World, tank: Tank): InputCommand {
+  const profile = profileOf(tank.color);
+  const ai = tank.ai ?? createAiState();
+  tank.ai = ai;
+
+  if (ai.fireCooldownTicks > 0) ai.fireCooldownTicks--;
+
+  const target = findTarget(world, tank, profile);
+
+  // ── Visée ──
+  // Recalcul périodique et décalé par identifiant, pour lisser le coût.
+  if (target && (world.tick + tank.id) % AIM_PERIOD_TICKS === 0) {
+    ai.solutionAngle = findFiringSolution(world.grid, tank.x, tank.y, target.x, target.y, {
+      bounces: profile.plannedBounces,
+      avoid: world.tanks
+        .filter((other) => other.alive && (other.id === tank.id || other.playerId === null))
+        .map((other) => ({ x: other.x, y: other.y })),
+      hitRadius: TUNING.tank.sizeTiles / 2,
+    });
+  } else if (!target) {
+    ai.solutionAngle = null;
+  }
+
+  // Faute de solution, la tourelle reste pointée vers la cible : le joueur voit
+  // ainsi qu'il est repéré, et le tank est prêt dès qu'un angle s'ouvre.
+  const aim =
+    ai.solutionAngle ??
+    (target ? Math.atan2(target.y - tank.y, target.x - tank.x) : tank.turretAngle);
+
+  // ── Tir ──
+  // On ne tire qu'une fois la tourelle effectivement alignée : sinon l'obus
+  // partirait dans la direction où le canon se trouve, pas où il vise.
+  const aligned = Math.abs(normalizeAngle(aim - tank.turretAngle)) <= AIM_TOLERANCE_RADIANS;
+  const fire = ai.solutionAngle !== null && aligned && ai.fireCooldownTicks === 0;
+
+  if (fire) {
+    const jitter = profile.fireIntervalJitterSeconds * nextFloat(world.rng);
+    ai.fireCooldownTicks = secondsToTicks(profile.fireIntervalSeconds + jitter);
+  }
+
+  // ── Déplacement ──
+  updateRoaming(world, tank, ai);
+
+  // L'esquive prime sur tout le reste : rester en vie d'abord. Elle ne
+  // s'applique qu'aux tanks réellement mobiles — un brun ou un vert sont des
+  // tourelles fixes, et leur faire « tenter » une esquive n'aurait aucun effet
+  // tout en brouillant leur comportement.
+  const mobile = profile.speedMultiplier > 0 && profile.movement !== 'hold';
+  const evasion = mobile ? findEvasion(tank, world.shells) : null;
+  const heading = evasion ?? desiredHeading(world, tank, ai, profile, target);
+
+  return {
+    moveX: heading.x,
+    moveY: heading.y,
+    // Le cône d'erreur du profil s'applique au tir, jamais à l'orientation
+    // affichée : la tourelle doit rester lisible pour le joueur.
+    aim,
+    fire,
+    mine: false,
+  };
+}
+
+/**
+ * Écart de visée appliqué au moment du tir.
+ *
+ * Séparé de l'intention pour que l'erreur soit tirée une fois par obus, et non
+ * à chaque pas — sinon la tourelle tremblerait à l'écran.
+ */
+export function aimErrorFor(world: World, tank: Tank): number {
+  const spread = profileOf(tank.color).aimErrorRadians;
+  return spread === 0 ? 0 : nextRange(world.rng, -spread / 2, spread / 2);
+}

--- a/src/core/systems/ai/profiles.ts
+++ b/src/core/systems/ai/profiles.ts
@@ -1,0 +1,293 @@
+/**
+ * Caractéristiques des neuf couleurs de tanks, entièrement en données.
+ *
+ * ─── Provenance ──────────────────────────────────────────────────────────────
+ *
+ * Tout ce fichier est transcrit depuis `legacy/src/constants.ts` et
+ * `legacy/src/enemy.ts`, où ces valeurs avaient été relevées sur le jeu
+ * original. Rien n'y est inventé, à deux exceptions signalées sur place.
+ *
+ * Deux conversions ont été nécessaires :
+ *
+ *   - les **vitesses de déplacement** étaient des multiplicateurs de la vitesse
+ *     du joueur ; elles le restent, la vitesse de référence vivant dans
+ *     `tuning.ts` ;
+ *   - les **vitesses de rotation de tourelle** étaient en radians par frame.
+ *     Elles sont converties en radians par seconde à 60 Hz, ce qui donne un
+ *     étalement de 3,3 s (brun) à 0,5 s (noir) pour un quart de tour.
+ *
+ * Note sur ce second point : le commentaire d'origine annonçait « environ 1 à
+ * 2 secondes pour 90° » pour le tank brun, ce que la valeur brute ne donne pas.
+ * Contrairement aux vitesses de déplacement, aucune mention d'ajustement
+ * empirique n'accompagnait ces nombres — on garde donc les valeurs, et on
+ * considère que c'est le commentaire qui était approximatif.
+ *
+ * ─── Règle ───────────────────────────────────────────────────────────────────
+ *
+ * Aucun `switch` sur la couleur ne doit exister ailleurs dans la logique.
+ * L'ancienne version en avait trois, dispersés dans la classe `Enemy`
+ * (`adjustAITimings`, `getAccuracy`, `updateMovement`), ce qui obligeait à
+ * toucher trois endroits pour ajuster un seul comportement.
+ */
+
+import type { ShellKind, TankColor } from '../../state.js';
+import { TILE_SIZE_PX } from '../../tuning.js';
+
+/** Manière dont un tank se déplace vis-à-vis de sa cible. */
+export type MovementStyle =
+  /** Ne bouge jamais. */
+  | 'hold'
+  /** Patrouille sans tenir compte de la cible. */
+  | 'patrol'
+  /** Garde ses distances, recule si la cible approche. */
+  | 'keepAway'
+  /** Se rapproche jusqu'à portée utile. */
+  | 'hunt'
+  /** Alterne sans logique apparente entre approche et déplacement erratique. */
+  | 'erratic';
+
+export interface TankProfile {
+  /** Multiplicateur de la vitesse de référence du joueur. */
+  speedMultiplier: number;
+  /** Vitesse de rotation de la tourelle, en radians par seconde. */
+  turretRateRadiansPerSecond: number;
+
+  /** Obus simultanés autorisés. */
+  maxActiveShells: number;
+  shellKind: ShellKind;
+  /** Rebonds autorisés par obus. */
+  shellBounces: number;
+
+  /** Mines simultanées autorisées. 0 pour les tanks qui n'en posent pas. */
+  maxActiveMines: number;
+
+  /** Délai moyen entre deux tirs, en secondes. */
+  fireIntervalSeconds: number;
+  /** Amplitude aléatoire ajoutée au délai, en secondes. 0 = cadence régulière. */
+  fireIntervalJitterSeconds: number;
+
+  /**
+   * Ouverture du cône d'erreur de visée, en radians.
+   *
+   * L'écart appliqué est tiré uniformément dans ±moitié de cette valeur.
+   */
+  aimErrorRadians: number;
+
+  /** Portée de détection de la cible, en tuiles. */
+  detectionRangeTiles: number;
+
+  /** Nombre de rebonds que l'IA envisage en cherchant un angle de tir. */
+  plannedBounces: number;
+
+  movement: MovementStyle;
+  /** Distance que le style de déplacement cherche à tenir, en tuiles. */
+  preferredRangeTiles: number;
+
+  /** Le tank est-il invisible tant qu'il ne tire pas ? */
+  invisible: boolean;
+}
+
+/** Conversion des rotations relevées en radians par frame à 60 Hz. */
+const perFrameToPerSecond = (radiansPerFrame: number): number => radiansPerFrame * 60;
+
+/** Les portées étaient relevées en pixels. */
+const pixelsToTiles = (pixels: number): number => pixels / TILE_SIZE_PX;
+
+/** Portée de détection standard : environ un tiers de la largeur de l'arène. */
+const STANDARD_RANGE = pixelsToTiles(267);
+/** Portée étendue, relevée pour les tanks qui repèrent de loin. */
+const LONG_RANGE = pixelsToTiles(400);
+
+export const TANK_PROFILES: Record<TankColor, TankProfile> = {
+  /**
+   * Le joueur. Sa tourelle suit le pointeur sans inertie — d'où une vitesse de
+   * rotation infinie, qui court-circuite le limiteur appliqué aux autres.
+   */
+  player: {
+    speedMultiplier: 1,
+    turretRateRadiansPerSecond: Number.POSITIVE_INFINITY,
+    maxActiveShells: 5,
+    shellKind: 'normal',
+    shellBounces: 1,
+    maxActiveMines: 2,
+    fireIntervalSeconds: 0,
+    fireIntervalJitterSeconds: 0,
+    aimErrorRadians: 0,
+    detectionRangeTiles: Number.POSITIVE_INFINITY,
+    plannedBounces: 0,
+    movement: 'hold',
+    preferredRangeTiles: 0,
+    invisible: false,
+  },
+
+  /** Brun : immobile, lent à viser, tire rarement. La cible d'entraînement. */
+  brown: {
+    speedMultiplier: 0,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.008),
+    maxActiveShells: 1,
+    shellKind: 'normal',
+    shellBounces: 1,
+    maxActiveMines: 0,
+    fireIntervalSeconds: 4,
+    fireIntervalJitterSeconds: 4,
+    aimErrorRadians: 0.8,
+    detectionRangeTiles: STANDARD_RANGE,
+    plannedBounces: 0,
+    movement: 'hold',
+    preferredRangeTiles: 0,
+    invisible: false,
+  },
+
+  /** Cendre : patrouille lentement et garde ses distances. Repère de loin. */
+  ash: {
+    speedMultiplier: 0.5,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.025),
+    maxActiveShells: 1,
+    shellKind: 'normal',
+    shellBounces: 1,
+    maxActiveMines: 0,
+    fireIntervalSeconds: 3,
+    fireIntervalJitterSeconds: 2,
+    aimErrorRadians: 0.4,
+    detectionRangeTiles: LONG_RANGE,
+    plannedBounces: 1,
+    movement: 'keepAway',
+    preferredRangeTiles: 5,
+    invisible: false,
+  },
+
+  /** Sarcelle : lent, mais son missile ne rebondit pas et arrive vite. */
+  teal: {
+    speedMultiplier: 0.5,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.025),
+    maxActiveShells: 1,
+    shellKind: 'fast',
+    shellBounces: 0,
+    maxActiveMines: 0,
+    fireIntervalSeconds: 2.5,
+    fireIntervalJitterSeconds: 0,
+    aimErrorRadians: 0.3,
+    detectionRangeTiles: STANDARD_RANGE,
+    // Un missile ne rebondit pas : chercher un angle à rebonds n'aurait aucun sens.
+    plannedBounces: 0,
+    movement: 'patrol',
+    preferredRangeTiles: 6,
+    invisible: false,
+  },
+
+  /** Jaune : rapide et imprévisible, mais vise mal. */
+  yellow: {
+    speedMultiplier: 1.5,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.02),
+    maxActiveShells: 1,
+    shellKind: 'normal',
+    shellBounces: 1,
+    maxActiveMines: 0,
+    fireIntervalSeconds: 1.5,
+    fireIntervalJitterSeconds: 2,
+    aimErrorRadians: 0.6,
+    detectionRangeTiles: STANDARD_RANGE,
+    plannedBounces: 1,
+    movement: 'erratic',
+    preferredRangeTiles: 4,
+    invisible: false,
+  },
+
+  /** Rose : cadence soutenue, trois obus en vol, se rapproche. */
+  pink: {
+    speedMultiplier: 1,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.035),
+    maxActiveShells: 3,
+    shellKind: 'normal',
+    shellBounces: 1,
+    maxActiveMines: 0,
+    fireIntervalSeconds: 1,
+    fireIntervalJitterSeconds: 0,
+    aimErrorRadians: 0.2,
+    detectionRangeTiles: STANDARD_RANGE,
+    plannedBounces: 1,
+    movement: 'hunt',
+    preferredRangeTiles: 3,
+    invisible: false,
+  },
+
+  /**
+   * Vert : immobile, mais c'est le tireur d'élite du jeu. Missiles à deux
+   * rebonds et cône d'erreur minuscule — il vous atteint derrière un mur.
+   */
+  green: {
+    speedMultiplier: 0,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.04),
+    maxActiveShells: 2,
+    shellKind: 'fast',
+    shellBounces: 2,
+    maxActiveMines: 0,
+    fireIntervalSeconds: 1.8,
+    fireIntervalJitterSeconds: 0,
+    aimErrorRadians: 0.05,
+    detectionRangeTiles: LONG_RANGE,
+    plannedBounces: 2,
+    movement: 'hold',
+    preferredRangeTiles: 0,
+    invisible: false,
+  },
+
+  /** Violet : rapide, cinq obus en vol, traque sans relâche. */
+  purple: {
+    speedMultiplier: 1.5,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.045),
+    maxActiveShells: 5,
+    shellKind: 'normal',
+    shellBounces: 1,
+    maxActiveMines: 2,
+    fireIntervalSeconds: 1,
+    fireIntervalJitterSeconds: 0,
+    aimErrorRadians: 0.2,
+    detectionRangeTiles: STANDARD_RANGE,
+    plannedBounces: 1,
+    movement: 'hunt',
+    preferredRangeTiles: 3,
+    invisible: false,
+  },
+
+  /** Blanc : les mêmes armes que le violet, mais invisible. */
+  white: {
+    speedMultiplier: 1,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.04),
+    maxActiveShells: 5,
+    shellKind: 'normal',
+    shellBounces: 1,
+    maxActiveMines: 2,
+    fireIntervalSeconds: 1,
+    fireIntervalJitterSeconds: 0,
+    aimErrorRadians: 0.2,
+    detectionRangeTiles: STANDARD_RANGE,
+    plannedBounces: 1,
+    movement: 'hunt',
+    preferredRangeTiles: 4,
+    invisible: true,
+  },
+
+  /** Noir : le plus rapide, missiles sans rebond, cadence la plus élevée. */
+  black: {
+    speedMultiplier: 2,
+    turretRateRadiansPerSecond: perFrameToPerSecond(0.05),
+    maxActiveShells: 3,
+    shellKind: 'fast',
+    shellBounces: 0,
+    maxActiveMines: 2,
+    fireIntervalSeconds: 0.6,
+    fireIntervalJitterSeconds: 0,
+    aimErrorRadians: 0.25,
+    detectionRangeTiles: LONG_RANGE,
+    plannedBounces: 0,
+    movement: 'hunt',
+    preferredRangeTiles: 3,
+    invisible: false,
+  },
+};
+
+/** Profil d'une couleur donnée. */
+export function profileOf(color: TankColor): TankProfile {
+  return TANK_PROFILES[color];
+}

--- a/src/core/systems/ai/threat.ts
+++ b/src/core/systems/ai/threat.ts
@@ -1,0 +1,72 @@
+/**
+ * Détection et esquive des obus entrants.
+ *
+ * Sans cela, un tank ennemi encaisse passivement tout ce qu'on lui envoie, ce
+ * qui rend les missions triviales dès qu'on a compris les angles. Dans
+ * l'original, les tanks mobiles se décalent quand un obus arrive sur eux.
+ */
+
+import { TUNING } from '../../tuning.js';
+import type { Shell, Tank } from '../../state.js';
+
+/**
+ * Anticipation de l'esquive, en secondes.
+ *
+ * Un obus qui arrivera dans plus d'une seconde ne mérite pas encore de
+ * réaction : le tank aurait le temps de se décaler puis de revenir dedans.
+ */
+const REACTION_HORIZON_SECONDS = 1;
+
+/** Largeur du couloir considéré comme menaçant, en tuiles. */
+const THREAT_CORRIDOR_TILES = TUNING.tank.sizeTiles;
+
+/** Direction dans laquelle s'écarter, ou `null` si rien ne menace. */
+export interface EvasionVector {
+  x: number;
+  y: number;
+}
+
+/**
+ * Cherche l'obus le plus pressant et rend la direction pour s'en écarter.
+ *
+ * On ne considère que la trajectoire **actuelle** de l'obus, sans ses rebonds à
+ * venir : anticiper un ricochet donnerait à l'IA une prescience que le joueur
+ * n'a pas, et rendrait les tanks agaçants plutôt que vivants.
+ */
+export function findEvasion(tank: Tank, shells: readonly Shell[]): EvasionVector | null {
+  let closestTime = Number.POSITIVE_INFINITY;
+  let evasion: EvasionVector | null = null;
+
+  for (const shell of shells) {
+    // Un tank n'esquive pas ses propres obus : ils partent de lui.
+    if (shell.ownerId === tank.id) continue;
+
+    const speed = Math.hypot(shell.vx, shell.vy);
+    if (speed === 0) continue;
+
+    const dirX = shell.vx / speed;
+    const dirY = shell.vy / speed;
+
+    // Projection du tank sur l'axe de l'obus.
+    const toTankX = tank.x - shell.x;
+    const toTankY = tank.y - shell.y;
+    const along = toTankX * dirX + toTankY * dirY;
+
+    // Derrière l'obus, ou trop loin devant pour être une menace immédiate.
+    if (along <= 0) continue;
+    const timeToReach = along / speed;
+    if (timeToReach > REACTION_HORIZON_SECONDS || timeToReach >= closestTime) continue;
+
+    // Écart latéral : l'obus passe-t-il assez près pour toucher ?
+    const lateral = toTankX * -dirY + toTankY * dirX;
+    if (Math.abs(lateral) > THREAT_CORRIDOR_TILES) continue;
+
+    closestTime = timeToReach;
+    // On s'écarte perpendiculairement, du côté où l'on est déjà. Fuir dans
+    // l'axe de l'obus serait perdu d'avance : il va bien plus vite.
+    const side = lateral >= 0 ? 1 : -1;
+    evasion = { x: -dirY * side, y: dirX * side };
+  }
+
+  return evasion;
+}

--- a/src/core/systems/mines.ts
+++ b/src/core/systems/mines.ts
@@ -16,6 +16,7 @@ import { TileKind } from '../state.js';
 import { secondsToTicks } from '../tick.js';
 import { TUNING } from '../tuning.js';
 import { allocateEntityId } from '../world.js';
+import { profileOf } from './ai/profiles.js';
 import type { EntityId, InputCommand, Mine, Tank, World } from '../state.js';
 
 /**
@@ -26,7 +27,8 @@ import type { EntityId, InputCommand, Mine, Tank, World } from '../state.js';
 export function layMine(world: World, tank: Tank): Mine | null {
   if (!tank.alive) return null;
   if (tank.mineReloadTicks > 0) return null;
-  if (tank.activeMines >= TUNING.tank.maxActiveMines) return null;
+  // Le quota vient du profil : plusieurs couleurs n'en posent pas du tout.
+  if (tank.activeMines >= profileOf(tank.color).maxActiveMines) return null;
 
   const mine: Mine = {
     id: allocateEntityId(world),

--- a/src/core/systems/movement.ts
+++ b/src/core/systems/movement.ts
@@ -15,22 +15,22 @@ import { blocksTank, sweepAxis } from '../grid.js';
 import { limitToUnitDisc, rotateToward } from '../math.js';
 import { DT } from '../tick.js';
 import { TUNING } from '../tuning.js';
+import { profileOf } from './ai/profiles.js';
 import type { InputCommand, Tank, World } from '../state.js';
-
-/**
- * Vitesse de déplacement d'un tank, en tuiles par seconde.
- *
- * Le multiplicateur par couleur arrive avec les profils d'IA (#11) ; d'ici là,
- * tous les tanks avancent à la vitesse de référence du joueur.
- */
-function speedOf(_tank: Tank): number {
-  return TUNING.tank.speedTilesPerSecond;
-}
 
 /** Applique l'intention d'un tick à un tank. */
 export function applyMovement(world: World, tank: Tank, input: InputCommand): void {
-  // La tourelle suit la visée sans inertie : elle est pointée, pas pilotée.
-  tank.turretAngle = input.aim;
+  const profile = profileOf(tank.color);
+
+  // La tourelle du joueur suit le pointeur sans inertie — son profil déclare
+  // une vitesse de rotation infinie, que `rotateToward` traite comme un
+  // alignement immédiat. Les tanks de l'IA, eux, mettent un temps mesurable à
+  // se retourner, et c'est ce délai qui rend leurs tirs esquivables.
+  tank.turretAngle = rotateToward(
+    tank.turretAngle,
+    input.aim,
+    profile.turretRateRadiansPerSecond * DT,
+  );
 
   if (!tank.alive) return;
 
@@ -47,15 +47,43 @@ export function applyMovement(world: World, tank: Tank, input: InputCommand): vo
       TUNING.tank.turnRateRadiansPerSecond * DT,
     );
 
-    const step = speedOf(tank) * DT;
+    const step = TUNING.tank.speedTilesPerSecond * profile.speedMultiplier * DT;
     const half = TUNING.tank.sizeTiles / 2;
 
     // X d'abord, puis Y avec le X déjà résolu : c'est cet enchaînement qui
     // produit le glissement. Tester les deux axes ensemble rejetterait le
     // déplacement entier dès qu'un seul des deux est bloqué.
+    const originX = tank.x;
     tank.x = sweepAxis(world.grid, tank.x, tank.y, half, blocksTank, 'x', direction.x * step);
+    if (overlapsAnotherTank(world, tank)) tank.x = originX;
+
+    const originY = tank.y;
     tank.y = sweepAxis(world.grid, tank.x, tank.y, half, blocksTank, 'y', direction.y * step);
+    if (overlapsAnotherTank(world, tank)) tank.y = originY;
   }
+}
+
+/**
+ * Le tank chevauche-t-il un autre tank vivant ?
+ *
+ * Les tanks sont des obstacles les uns pour les autres : sans ça, deux tanks de
+ * l'IA qui convergent vers la même position finissent superposés, ce qui est
+ * autant un défaut visuel qu'un défaut de jeu — deux tanks empilés se
+ * comportent comme un seul.
+ *
+ * Le test est fait après chaque axe, et l'axe fautif est simplement annulé. Un
+ * tank bloqué par un autre glisse donc le long de lui, exactement comme le long
+ * d'un mur.
+ */
+function overlapsAnotherTank(world: World, tank: Tank): boolean {
+  const size = TUNING.tank.sizeTiles;
+
+  for (const other of world.tanks) {
+    if (other.id === tank.id || !other.alive) continue;
+    if (Math.abs(other.x - tank.x) < size && Math.abs(other.y - tank.y) < size) return true;
+  }
+
+  return false;
 }
 
 /**

--- a/src/core/systems/shells.ts
+++ b/src/core/systems/shells.ts
@@ -11,6 +11,8 @@ import { blocksShell, boxOverlapsSolid, sweepBoxAgainstGrid } from '../grid.js';
 import { DT, secondsToTicks } from '../tick.js';
 import { TUNING } from '../tuning.js';
 import { allocateEntityId } from '../world.js';
+import { aimErrorFor } from './ai/brain.js';
+import { profileOf } from './ai/profiles.js';
 import type { EntityId, InputCommand, Shell, ShellKind, Tank, World } from '../state.js';
 
 /**
@@ -25,15 +27,6 @@ const MAX_BOUNCES_PER_TICK = 8;
 /** Écart laissé entre l'obus et le mur après un rebond. */
 const SEPARATION_EPSILON = 1e-6;
 
-/** Caractéristiques de tir, fournies par le profil du tank (#11). */
-export interface ShellSpec {
-  kind: ShellKind;
-  bounces: number;
-}
-
-/** Le joueur tire des obus normaux à un rebond, comme dans l'original. */
-const PLAYER_SHELL: ShellSpec = { kind: 'normal', bounces: 1 };
-
 /** Vitesse associée à un type d'obus, en tuiles par seconde. */
 export function shellSpeed(kind: ShellKind): number {
   return kind === 'fast'
@@ -44,16 +37,27 @@ export function shellSpeed(kind: ShellKind): number {
 /**
  * Fait tirer un tank, si son quota et son rechargement le permettent.
  *
+ * Le type d'obus, le nombre de rebonds et le quota viennent du profil de la
+ * couleur : un tank vert tire des missiles à deux rebonds, un noir des missiles
+ * sans rebond, sans qu'aucun `switch` n'apparaisse ici.
+ *
  * @returns l'obus créé, ou `null` si le tir a été refusé
  */
-export function fireShell(world: World, tank: Tank, spec: ShellSpec = PLAYER_SHELL): Shell | null {
+export function fireShell(world: World, tank: Tank): Shell | null {
   if (!tank.alive) return null;
   if (tank.reloadTicks > 0) return null;
-  if (tank.activeShells >= TUNING.tank.maxActiveShells) return null;
 
-  const speed = shellSpeed(spec.kind);
-  const dirX = Math.cos(tank.turretAngle);
-  const dirY = Math.sin(tank.turretAngle);
+  const profile = profileOf(tank.color);
+  if (tank.activeShells >= profile.maxActiveShells) return null;
+
+  const speed = shellSpeed(profile.shellKind);
+
+  // Le cône d'erreur s'applique ici, au moment du tir, et non à l'orientation
+  // de la tourelle : appliqué en continu, il ferait trembler le canon à
+  // l'écran au lieu de disperser les tirs.
+  const angle = tank.turretAngle + aimErrorFor(world, tank);
+  const dirX = Math.cos(angle);
+  const dirY = Math.sin(angle);
 
   // L'obus naît au bout du canon. Si ce point tombe dans un mur — canon collé
   // contre un bloc — on le fait naître au centre du tank : le faire apparaître
@@ -74,12 +78,12 @@ export function fireShell(world: World, tank: Tank, spec: ShellSpec = PLAYER_SHE
   const shell: Shell = {
     id: allocateEntityId(world),
     ownerId: tank.id,
-    kind: spec.kind,
+    kind: profile.shellKind,
     x,
     y,
     vx: dirX * speed,
     vy: dirY * speed,
-    bouncesLeft: spec.bounces,
+    bouncesLeft: profile.shellBounces,
     // L'obus part désarmé : il chevauche encore son tireur.
     armed: false,
   };

--- a/src/core/tick.ts
+++ b/src/core/tick.ts
@@ -14,6 +14,7 @@
  * dérivaient l'un de l'autre.
  */
 
+import { decideAiInput } from './systems/ai/brain.js';
 import { resolveShellShellHits, resolveShellTankHits } from './systems/damage.js';
 import { removeDoomedMines, updateMineLaying, updateMines } from './systems/mines.js';
 import { updateMovement } from './systems/movement.js';
@@ -59,8 +60,16 @@ export type TickInputs = ReadonlyArray<readonly [tankId: EntityId, input: InputC
  * figé ici, et le test de déterminisme le verrouille.
  */
 export function tick(world: World, inputs: TickInputs): void {
-  // 1. Décisions de l'IA : renseigne les intentions des tanks non joueurs → #11
+  // 1. Décisions de l'IA. Elle produit exactement le même `InputCommand` qu'un
+  //    joueur et passe par les mêmes systèmes : un ennemi ne peut donc pas se
+  //    déplacer plus vite ni tirer plus souvent que ne l'autorisent les règles.
   const intents = new Map(inputs);
+
+  for (const tank of world.tanks) {
+    if (tank.playerId === null && tank.alive && !intents.has(tank.id)) {
+      intents.set(tank.id, decideAiInput(world, tank));
+    }
+  }
 
   // 2. Déplacement des tanks : résolution X puis Y, glissement le long des murs.
   updateMovement(world, intents);

--- a/src/core/tuning.ts
+++ b/src/core/tuning.ts
@@ -125,7 +125,10 @@ export const TUNING: Tuning = {
     // Environ un demi-tour en un tiers de seconde : le corps s'oriente vite
     // sans donner l'impression de pivoter instantanément.
     turnRateRadiansPerSecond: Math.PI * 3,
+    // 5, et non le 4 que fixait `legacy/src/game.ts` : cette valeur-là était un
+    // choix d'implémentation, pas un relevé.
     maxActiveShells: 5,
+    // ⚠ Non mesuré — voir la section `mine` plus bas.
     maxActiveMines: 2,
   },
   shell: {
@@ -134,6 +137,17 @@ export const TUNING: Tuning = {
     fastSpeedTilesPerSecond: speedFromCrossing(SHELL_CROSSING_SECONDS) * 2,
     cooldownSeconds: 0.2,
   },
+  // ⚠ SECTION NON MESURÉE — en attente de relevé sur le jeu original.
+  //
+  // Contrairement à tout le reste de ce fichier, ces valeurs ne dérivent
+  // d'aucune mesure : les mines n'ayant jamais été implémentées dans la version
+  // précédente, il n'y avait rien à en extraire. Ce sont des estimations.
+  //
+  // À relever, par la même méthode que les vitesses (comptage d'images) :
+  //   · fuseSeconds      → temps entre la pose et l'explosion
+  //   · blastRadiusTiles → portée du souffle, en nombre de blocs détruits
+  //   · cooldownSeconds  → délai minimal observé entre deux poses
+  // Et à confirmer : le nombre de mines simultanées (`tank.maxActiveMines`).
   mine: {
     fuseSeconds: 3,
     // Deux tuiles : de quoi ouvrir un passage franc dans un mur cassable, ce

--- a/src/core/world.ts
+++ b/src/core/world.ts
@@ -7,6 +7,7 @@
  */
 
 import { createRng } from './rng.js';
+import { createAiState } from './systems/ai/brain.js';
 import { TileKind } from './state.js';
 import type { EntityId, Grid, Tank, TankColor, World } from './state.js';
 
@@ -85,11 +86,12 @@ export interface TankOptions {
  */
 export function createTank(world: World, options: TankOptions): Tank {
   const angle = options.angle ?? 0;
+  const playerId = options.playerId ?? null;
 
   const tank: Tank = {
     id: allocateEntityId(world),
     color: options.color,
-    playerId: options.playerId ?? null,
+    playerId,
     x: options.x,
     y: options.y,
     bodyAngle: angle,
@@ -99,6 +101,8 @@ export function createTank(world: World, options: TankOptions): Tank {
     activeMines: 0,
     reloadTicks: 0,
     mineReloadTicks: 0,
+    // Un tank sans joueur est piloté par l'IA, et reçoit donc sa mémoire.
+    ai: playerId === null ? createAiState() : null,
   };
 
   world.tanks.push(tank);

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -1,0 +1,529 @@
+import { describe, expect, test } from 'bun:test';
+
+import { setTile } from '../src/core/grid.js';
+import { TileKind } from '../src/core/state.js';
+import type { Tank, TankColor, World } from '../src/core/state.js';
+import { TICK_RATE, tick } from '../src/core/tick.js';
+import { findFiringSolution, pathReaches, traceShellPath } from '../src/core/systems/ai/aiming.js';
+import { TANK_PROFILES, profileOf } from '../src/core/systems/ai/profiles.js';
+import { findEvasion } from '../src/core/systems/ai/threat.js';
+import { TUNING } from '../src/core/tuning.js';
+import { allocateEntityId, createTank, createWorld, hashWorld } from '../src/core/world.js';
+
+/**
+ * La visée avec rebonds est la mécanique signature du jeu : un ennemi vous
+ * atteint **derrière un mur**. L'ancienne version visait en ligne droite avec
+ * du bruit aléatoire, ce qui rendait tout ennemi masqué parfaitement inoffensif.
+ */
+
+function openWorld(width = 30, height = 20): World {
+  return createWorld({ width, height, seed: 1 });
+}
+
+function addPlayer(world: World, x: number, y: number): Tank {
+  return createTank(world, { color: 'player', playerId: 'p1', x, y });
+}
+
+function addEnemy(world: World, color: TankColor, x: number, y: number): Tank {
+  return createTank(world, { color, x, y });
+}
+
+function advance(world: World, ticks: number): void {
+  for (let i = 0; i < ticks; i++) tick(world, []);
+}
+
+/** Mur vertical complet, avec une ouverture optionnelle. */
+function verticalWall(world: World, x: number, fromY: number, toY: number): void {
+  for (let y = fromY; y <= toY; y++) setTile(world.grid, x, y, TileKind.Indestructible);
+}
+
+describe('profils — conformité aux relevés', () => {
+  test('les neuf couleurs et le joueur sont définis', () => {
+    const colors: TankColor[] = [
+      'player',
+      'brown',
+      'ash',
+      'teal',
+      'yellow',
+      'pink',
+      'green',
+      'purple',
+      'white',
+      'black',
+    ];
+
+    for (const color of colors) {
+      expect(TANK_PROFILES[color]).toBeDefined();
+    }
+  });
+
+  test('les multiplicateurs de vitesse correspondent aux valeurs relevées', () => {
+    // Relevés dans legacy/src/constants.ts.
+    expect(profileOf('brown').speedMultiplier).toBe(0);
+    expect(profileOf('green').speedMultiplier).toBe(0);
+    expect(profileOf('ash').speedMultiplier).toBe(0.5);
+    expect(profileOf('teal').speedMultiplier).toBe(0.5);
+    expect(profileOf('pink').speedMultiplier).toBe(1);
+    expect(profileOf('white').speedMultiplier).toBe(1);
+    expect(profileOf('yellow').speedMultiplier).toBe(1.5);
+    expect(profileOf('purple').speedMultiplier).toBe(1.5);
+    expect(profileOf('black').speedMultiplier).toBe(2);
+  });
+
+  test('les armements correspondent aux valeurs relevées', () => {
+    // Relevés dans legacy/src/enemy.ts (maxBullets, bulletRicochets, bulletSpeed).
+    const expected: Partial<Record<TankColor, [shells: number, bounces: number, fast: boolean]>> = {
+      brown: [1, 1, false],
+      ash: [1, 1, false],
+      teal: [1, 0, true],
+      yellow: [1, 1, false],
+      pink: [3, 1, false],
+      green: [2, 2, true],
+      purple: [5, 1, false],
+      white: [5, 1, false],
+      black: [3, 0, true],
+    };
+
+    for (const [color, [shells, bounces, fast]] of Object.entries(expected)) {
+      const profile = profileOf(color as TankColor);
+      expect(profile.maxActiveShells).toBe(shells);
+      expect(profile.shellBounces).toBe(bounces);
+      expect(profile.shellKind).toBe(fast ? 'fast' : 'normal');
+    }
+  });
+
+  test('la tourelle du joueur suit le pointeur sans inertie', () => {
+    expect(profileOf('player').turretRateRadiansPerSecond).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  test('les tourelles ennemies tournent à vitesse finie et ordonnée', () => {
+    // Le brun est le plus lent, le noir le plus rapide — comme dans les relevés.
+    const brown = profileOf('brown').turretRateRadiansPerSecond;
+    const black = profileOf('black').turretRateRadiansPerSecond;
+
+    expect(brown).toBeGreaterThan(0);
+    expect(Number.isFinite(black)).toBe(true);
+    expect(black).toBeGreaterThan(brown);
+  });
+
+  test('seul le tank blanc est invisible', () => {
+    const invisible = Object.entries(TANK_PROFILES)
+      .filter(([, profile]) => profile.invisible)
+      .map(([color]) => color);
+
+    expect(invisible).toEqual(['white']);
+  });
+
+  test('un missile ne planifie jamais de rebond', () => {
+    // Chercher un angle à rebonds pour un projectile qui n'en fait aucun
+    // n'aurait aucun sens.
+    for (const color of ['teal', 'black'] as const) {
+      const profile = profileOf(color);
+      expect(profile.shellBounces).toBe(0);
+      expect(profile.plannedBounces).toBe(0);
+    }
+  });
+});
+
+describe('tracé de trajectoire', () => {
+  test('sans obstacle, la trajectoire est un seul segment', () => {
+    const world = openWorld(40, 40);
+    const path = traceShellPath(world.grid, 20, 20, 0, 1, 10);
+
+    expect(path).toHaveLength(1);
+    expect(path[0]!.x1).toBeCloseTo(30, 6);
+  });
+
+  test('un rebond produit deux segments et inverse la direction', () => {
+    const world = openWorld(20, 20);
+    const path = traceShellPath(world.grid, 10, 10, 0, 1);
+
+    expect(path).toHaveLength(2);
+    // Le premier segment va vers la droite, le second revient.
+    expect(path[0]!.x1).toBeGreaterThan(path[0]!.x0);
+    expect(path[1]!.x1).toBeLessThan(path[1]!.x0);
+  });
+
+  test('le nombre de segments ne dépasse jamais le quota de rebonds', () => {
+    const world = openWorld(20, 20);
+    expect(traceShellPath(world.grid, 10, 10, 0.7, 0).length).toBeLessThanOrEqual(1);
+    expect(traceShellPath(world.grid, 10, 10, 0.7, 2).length).toBeLessThanOrEqual(3);
+  });
+
+  test('un point sur le trajet est détecté, un point à côté ne l\'est pas', () => {
+    const path = [{ x0: 0, y0: 0, x1: 10, y1: 0 }];
+
+    expect(pathReaches(path, 5, 0.1, 0.5)).toBeCloseTo(5, 6);
+    expect(pathReaches(path, 5, 3, 0.5)).toBeNull();
+  });
+});
+
+describe('recherche d\'angle de tir', () => {
+  const hitRadius = TUNING.tank.sizeTiles / 2;
+
+  test('en vue directe, l\'angle trouvé pointe vers la cible', () => {
+    const world = openWorld(30, 20);
+    const angle = findFiringSolution(world.grid, 5, 10, 20, 10, {
+      bounces: 1,
+      avoid: [],
+      hitRadius,
+    });
+
+    expect(angle).not.toBeNull();
+    expect(Math.abs(angle!)).toBeLessThan(0.05);
+  });
+
+  test('derrière un mur, une solution à un rebond est trouvée', () => {
+    // Mur partiel : il masque la ligne droite mais laisse un passage par le
+    // haut, atteignable en rebondissant sur la bordure.
+    const world = openWorld(30, 20);
+    verticalWall(world.grid ? world : world, 15, 6, 19);
+
+    const angle = findFiringSolution(world.grid, 8, 12, 22, 12, {
+      bounces: 1,
+      avoid: [],
+      hitRadius,
+    });
+
+    expect(angle).not.toBeNull();
+
+    // Et la trajectoire trouvée atteint bien la cible.
+    const path = traceShellPath(world.grid, 8, 12, angle!, 1);
+    expect(pathReaches(path, 22, 12, hitRadius)).not.toBeNull();
+  });
+
+  test('sans rebond autorisé, aucune solution derrière un mur', () => {
+    const world = openWorld(30, 20);
+    verticalWall(world, 15, 1, 18);
+
+    const angle = findFiringSolution(world.grid, 8, 10, 22, 10, {
+      bounces: 0,
+      avoid: [],
+      hitRadius,
+    });
+
+    expect(angle).toBeNull();
+  });
+
+  test('le tireur ne se disqualifie pas lui-même à la sortie du canon', () => {
+    // Le tireur figure toujours dans sa propre liste d'évitement. Sans marge au
+    // départ, chaque tir serait rejeté au motif qu'il passe sur le tireur —
+    // c'est-à-dire au moment où il quitte son canon.
+    const world = openWorld(30, 20);
+
+    const angle = findFiringSolution(world.grid, 5, 10, 25, 10, {
+      bounces: 0,
+      avoid: [{ x: 5, y: 10 }],
+      hitRadius,
+    });
+
+    expect(angle).not.toBeNull();
+  });
+
+  test('une trajectoire qui repasse sur le tireur plus loin est écartée', () => {
+    // Le cas que la marge de sortie ne doit pas masquer : l'obus revient sur
+    // son tireur après avoir parcouru du chemin. Sans ce contrôle, les profils
+    // à deux rebonds se suicideraient en boucle.
+    const world = openWorld(30, 20);
+
+    // Tir vers la droite, la cible est au-delà du mur du fond : la seule
+    // trajectoire possible rebondit et revient droit sur le point de départ.
+    const shooter = { x: 5, y: 10 };
+    const angle = findFiringSolution(world.grid, shooter.x, shooter.y, 28.5, 10, {
+      bounces: 2,
+      avoid: [shooter],
+      hitRadius,
+    });
+
+    if (angle !== null) {
+      // Si une solution est retenue, elle ne doit pas repasser sur le tireur
+      // avant d'atteindre la cible.
+      const path = traceShellPath(world.grid, shooter.x, shooter.y, angle, 2);
+      const backOnShooter = pathReaches(
+        path,
+        shooter.x,
+        shooter.y,
+        hitRadius,
+        TUNING.tank.sizeTiles,
+      );
+      const onTarget = pathReaches(path, 28.5, 10, hitRadius);
+
+      expect(backOnShooter === null || backOnShooter > onTarget!).toBe(true);
+    }
+  });
+
+  test('un allié sur la trajectoire écarte la solution', () => {
+    const world = openWorld(30, 20);
+
+    const withoutAlly = findFiringSolution(world.grid, 5, 10, 25, 10, {
+      bounces: 0,
+      avoid: [],
+      hitRadius,
+    });
+    expect(withoutAlly).not.toBeNull();
+
+    const withAlly = findFiringSolution(world.grid, 5, 10, 25, 10, {
+      bounces: 0,
+      avoid: [{ x: 15, y: 10 }],
+      hitRadius,
+    });
+    expect(withAlly).toBeNull();
+  });
+});
+
+describe('comportement en jeu', () => {
+  test('un tank brun oriente sa tourelle et tire vers le joueur', () => {
+    // On vérifie le mécanisme, pas la chance : le brun a le plus large cône
+    // d'erreur du jeu (0,8 rad) et la cadence la plus lente, si bien qu'il rate
+    // souvent. Ce qui doit être garanti, c'est qu'il vise et qu'il tire.
+    const world = openWorld(30, 20);
+    const player = addPlayer(world, 14, 10);
+    const brown = addEnemy(world, 'brown', 20, 10);
+
+    let fired = 0;
+    let towardsPlayer = 0;
+
+    for (let i = 0; i < 40 * TICK_RATE; i++) {
+      const before = world.shells.length;
+      tick(world, []);
+      if (world.shells.length > before) {
+        fired++;
+        const shell = world.shells[world.shells.length - 1]!;
+        // Le joueur est à gauche : un tir sensé part vers la gauche.
+        if (shell.vx < 0) towardsPlayer++;
+      }
+    }
+
+    expect(fired).toBeGreaterThan(0);
+    expect(towardsPlayer).toBe(fired);
+    // La tourelle a bien pivoté depuis son orientation initiale (vers la droite).
+    expect(Math.abs(brown.turretAngle)).toBeGreaterThan(2);
+  });
+
+  test('un tank vert touche un joueur masqué par un mur', () => {
+    // Le comportement signature du jeu, et ce qui manquait entièrement à
+    // l'ancienne version : le vert est immobile, mais c'est le tireur d'élite —
+    // missiles à deux rebonds et cône d'erreur de 0,05 rad. Aucune ligne droite
+    // ne relie les deux tanks ; la seule façon de toucher est de ricocher.
+    const world = openWorld(30, 20);
+    verticalWall(world, 15, 7, 12);
+
+    const player = addPlayer(world, 8, 10);
+    // Placé dans la portée de détection du profil (12,5 tuiles).
+    addEnemy(world, 'green', 19, 10);
+
+    // Ligne de vue directe effectivement coupée.
+    expect(
+      findFiringSolution(world.grid, 19, 10, player.x, player.y, {
+        bounces: 0,
+        avoid: [],
+        hitRadius: TUNING.tank.sizeTiles / 2,
+      }),
+    ).toBeNull();
+
+    advance(world, 30 * TICK_RATE);
+
+    expect(player.alive).toBe(false);
+  });
+
+  test('un ennemi ne se tue pas avec son propre tir', () => {
+    // Deux profils à rebonds, longuement laissés à eux-mêmes dans un espace
+    // clos : aucun ne doit finir par s'auto-détruire.
+    for (const color of ['green', 'ash'] as const) {
+      const world = openWorld(16, 12);
+      addPlayer(world, 3, 6);
+      const enemy = addEnemy(world, color, 12, 6);
+
+      advance(world, 40 * TICK_RATE);
+
+      expect(enemy.alive).toBe(true);
+    }
+  });
+
+  test('les tanks immobiles ne bougent jamais', () => {
+    const world = openWorld(30, 20);
+    addPlayer(world, 5, 10);
+
+    const brown = addEnemy(world, 'brown', 20, 10);
+    const green = addEnemy(world, 'green', 20, 15);
+    const origins = [
+      { x: brown.x, y: brown.y },
+      { x: green.x, y: green.y },
+    ];
+
+    advance(world, 20 * TICK_RATE);
+
+    expect({ x: brown.x, y: brown.y }).toEqual(origins[0]!);
+    expect({ x: green.x, y: green.y }).toEqual(origins[1]!);
+  });
+
+  test('un tank mobile se déplace', () => {
+    const world = openWorld(40, 30);
+    addPlayer(world, 5, 15);
+    const purple = addEnemy(world, 'purple', 30, 15);
+    const start = { x: purple.x, y: purple.y };
+
+    advance(world, 5 * TICK_RATE);
+
+    expect(Math.hypot(purple.x - start.x, purple.y - start.y)).toBeGreaterThan(1);
+  });
+
+  test('les tanks de l\'IA ne se tirent pas dessus entre eux', () => {
+    const world = openWorld(30, 20);
+    // Pas de joueur du tout : sans cible, personne ne doit ouvrir le feu.
+    const first = addEnemy(world, 'purple', 10, 10);
+    const second = addEnemy(world, 'pink', 20, 10);
+
+    advance(world, 20 * TICK_RATE);
+
+    expect(first.alive).toBe(true);
+    expect(second.alive).toBe(true);
+    expect(world.shells).toHaveLength(0);
+  });
+
+  test('un ennemi hors de portée ne réagit pas', () => {
+    const world = openWorld(60, 20);
+    const brown = addEnemy(world, 'brown', 55, 10);
+    // Très au-delà de la portée de détection du profil.
+    addPlayer(world, 3, 10);
+
+    advance(world, 10 * TICK_RATE);
+
+    expect(brown.ai!.solutionAngle).toBeNull();
+    expect(world.shells).toHaveLength(0);
+  });
+
+  test('respecte le quota d\'obus simultanés de son profil', () => {
+    const world = openWorld(40, 30);
+    addPlayer(world, 8, 15);
+    const purple = addEnemy(world, 'purple', 30, 15);
+
+    for (let i = 0; i < 20 * TICK_RATE; i++) {
+      tick(world, []);
+      expect(purple.activeShells).toBeLessThanOrEqual(profileOf('purple').maxActiveShells);
+    }
+  });
+});
+
+describe('esquive', () => {
+  test('un obus qui arrive de face déclenche un écart perpendiculaire', () => {
+    const world = openWorld();
+    const tank = addPlayer(world, 20, 10);
+
+    world.shells.push({
+      id: allocateEntityId(world),
+      ownerId: -1,
+      kind: 'normal',
+      x: 15,
+      y: 10,
+      vx: 5,
+      vy: 0,
+      bouncesLeft: 1,
+      armed: true,
+    });
+
+    const evasion = findEvasion(tank, world.shells);
+
+    expect(evasion).not.toBeNull();
+    // Perpendiculaire à un obus horizontal : uniquement vertical.
+    expect(Math.abs(evasion!.x)).toBeLessThan(1e-9);
+    expect(Math.abs(evasion!.y)).toBeCloseTo(1, 6);
+  });
+
+  test('un obus qui s\'éloigne ne déclenche rien', () => {
+    const world = openWorld();
+    const tank = addPlayer(world, 20, 10);
+
+    world.shells.push({
+      id: allocateEntityId(world),
+      ownerId: -1,
+      kind: 'normal',
+      x: 25,
+      y: 10,
+      vx: 5,
+      vy: 0,
+      bouncesLeft: 1,
+      armed: true,
+    });
+
+    expect(findEvasion(tank, world.shells)).toBeNull();
+  });
+
+  test('un obus qui passe largement à côté ne déclenche rien', () => {
+    const world = openWorld();
+    const tank = addPlayer(world, 20, 10);
+
+    world.shells.push({
+      id: allocateEntityId(world),
+      ownerId: -1,
+      kind: 'normal',
+      x: 15,
+      y: 16,
+      vx: 5,
+      vy: 0,
+      bouncesLeft: 1,
+      armed: true,
+    });
+
+    expect(findEvasion(tank, world.shells)).toBeNull();
+  });
+
+  test('un tank n\'esquive pas son propre obus', () => {
+    const world = openWorld();
+    const tank = addPlayer(world, 20, 10);
+
+    world.shells.push({
+      id: allocateEntityId(world),
+      ownerId: tank.id,
+      kind: 'normal',
+      x: 15,
+      y: 10,
+      vx: 5,
+      vy: 0,
+      bouncesLeft: 1,
+      armed: true,
+    });
+
+    expect(findEvasion(tank, world.shells)).toBeNull();
+  });
+});
+
+describe('déterminisme de l\'IA', () => {
+  test('une bataille rejouée depuis la même graine est identique', () => {
+    // L'IA tire au sort ses directions de patrouille et son cône d'erreur.
+    // Sans le PRNG du monde, chaque rejeu divergerait et la réconciliation
+    // réseau (#13) serait impossible.
+    const build = (): World => {
+      const world = createWorld({ width: 30, height: 20, seed: 4242 });
+      setTile(world.grid, 15, 9, TileKind.Indestructible);
+      setTile(world.grid, 15, 10, TileKind.Indestructible);
+
+      addPlayer(world, 6, 10);
+      addEnemy(world, 'purple', 24, 6);
+      addEnemy(world, 'green', 24, 14);
+      addEnemy(world, 'yellow', 20, 10);
+      return world;
+    };
+
+    const a = build();
+    const b = build();
+    advance(a, 20 * TICK_RATE);
+    advance(b, 20 * TICK_RATE);
+
+    expect(hashWorld(a)).toBe(hashWorld(b));
+  });
+
+  test('la mémoire de l\'IA survit à un aller-retour de sérialisation', () => {
+    const world = openWorld();
+    addPlayer(world, 5, 10);
+    addEnemy(world, 'purple', 20, 10);
+    advance(world, 120);
+
+    const revived = JSON.parse(JSON.stringify(world)) as World;
+    expect(hashWorld(revived)).toBe(hashWorld(world));
+
+    advance(world, 120);
+    advance(revived, 120);
+    expect(hashWorld(revived)).toBe(hashWorld(world));
+  });
+});

--- a/tests/shells.test.ts
+++ b/tests/shells.test.ts
@@ -13,8 +13,15 @@ function openWorld(width = 40, height = 30): World {
   return createWorld({ width, height, seed: 1 });
 }
 
+/**
+ * Tank piloté par un joueur.
+ *
+ * `playerId` est explicite : un tank sans joueur est repris par l'IA, qui
+ * l'enverrait esquiver les obus qu'on lui tire dessus — ce qui n'est pas ce
+ * qu'on veut mesurer ici.
+ */
 function addTank(world: World, x: number, y: number, turretAngle = 0): Tank {
-  const tank = createTank(world, { color: 'player', x, y, angle: turretAngle });
+  const tank = createTank(world, { color: 'player', playerId: 'p1', x, y, angle: turretAngle });
   tank.bodyAngle = 0;
   return tank;
 }

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -31,6 +31,7 @@ describe('capture', () => {
       'color',
       'id',
       'turretAngle',
+      'visible',
       'x',
       'y',
     ]);


### PR DESCRIPTION
Closes #11

**Un tank vert atteint le joueur derrière un mur, d'un missile à deux ricochets.** C'est la mécanique signature du jeu, et elle était totalement absente.

## Ce que faisait l'ancienne IA

```ts
let targetAngle = Math.atan2(dy, dx);
targetAngle += (Math.random() - 0.5) * accuracy;
```

Visée en ligne droite, plus du bruit. Un ennemi masqué par un mur était donc **parfaitement inoffensif** — ce qui retire au jeu l'essentiel de sa tension.

## Les profils viennent de tes relevés

Tout `profiles.ts` est transcrit depuis `legacy/src/constants.ts` et `legacy/src/enemy.ts` : multiplicateurs de vitesse, obus simultanés, ricochets, type d'obus, rotation de tourelle, cadences de tir, cônes d'erreur, portées de détection. **Rien n'est inventé.**

Deux conversions ont été nécessaires : les rotations de tourelle passent de radians/frame à radians/seconde (à 60 Hz, ce qui donne 3,3 s pour un quart de tour au brun et 0,5 s au noir), et les portées de pixels en tuiles.

Une note est laissée dans le fichier : le commentaire d'origine annonçait « environ 1 à 2 secondes pour 90° » pour le brun, ce que la valeur brute ne donne pas. Contrairement aux vitesses de déplacement, aucune mention d'ajustement empirique n'accompagnait ces nombres — on garde donc les valeurs et on considère le commentaire approximatif.

Les trois `switch` sur le type d'IA de l'ancienne classe `Enemy` (`adjustAITimings`, `getAccuracy`, `updateMovement`) disparaissent : une seule machine à états, paramétrée par le profil.

## La recherche d'angle

Deux temps, parce que la ligne droite est de loin le cas le plus fréquent :

1. **Tir direct** — un seul lancer de rayon.
2. Sinon, **balayage de 180 directions** avec tracé des rebonds, en retenant la trajectoire **la plus courte** : celle qui laisse le moins de temps à la cible pour s'écarter.

Un pas de 2° est largement sous le cône d'erreur du profil le plus précis (le vert, à 0,05 rad ≈ 2,9°) : aller plus fin coûterait sans rien apporter.

### Le budget de calcul

Un lancer de rayon par **parcours de grille (DDA)** remplace le balayage de boîte pour ces tracés : une quarantaine de tuiles visitées au lieu de quatre cents sur un rayon diagonal de vingt tuiles. Sans ça, des centaines d'échantillons par recherche seraient hors budget.

Le recalcul est périodique (tous les 12 pas) et **décalé par identifiant de tank**, pour qu'aucun pas ne concentre plusieurs recherches. Le projectile y est traité comme un point — c'est une prédiction, et chaque profil applique de toute façon son cône d'erreur ; la physique réelle des obus reste le balayage exact.

### Sécurité de tir

Une trajectoire qui repasse sur le tireur ou sur un allié **avant** d'atteindre la cible est écartée. Sans ça, les profils à deux rebonds se suicident en boucle : la trajectoire la plus courte vers une cible proche repasse très souvent par le point de départ.

Une marge de sortie de canon évite le piège inverse — que le tireur se disqualifie lui-même au moment où l'obus quitte son canon, puisqu'il figure toujours dans sa propre liste d'évitement.

## L'IA n'a aucun privilège

Elle produit exactement le même `InputCommand` qu'un joueur et passe par les mêmes systèmes. Un ennemi ne peut donc pas se déplacer plus vite que ne l'autorise le mouvement, ni tirer plus souvent que son rechargement.

Sa mémoire (angle retenu, minuteurs, direction de patrouille) vit **dans l'état du monde**. Sinon un rejeu ou une réconciliation réseau (#13) repartirait avec une IA amnésique et les deux simulations divergeraient — un test le vérifie par aller-retour de sérialisation.

## Trois ajouts en chemin

**Les tanks se collisionnent entre eux.** Le violet et le cendre finissaient superposés à la même position : visible à l'écran, et deux tanks empilés se comportent comme un seul. Le test est fait après chaque axe, donc un tank bloqué par un autre glisse le long de lui comme le long d'un mur.

**Le tank blanc est invisible au repos** et se révèle en tirant — faute de quoi il serait impossible à combattre autrement qu'au hasard.

**Le bac à sable est refait en arène ouverte.** Le labyrinthe de couloirs d'une tuile ne laissait aucune ligne de tir ni angle de ricochet : tous les ennemis restaient muets, ce qui ressemblait à un bug d'IA alors que c'était un défaut de tracé. Les vraies arènes de l'original sont ouvertes avec des couverts épars — une leçon à retenir pour #12.

Un mode « arène calme » (`?calme=1`) permet aux tests de déplacement et de mines de mesurer sans se faire canarder.

## Vérification

| Commande | Résultat |
|---|---|
| `bun test ./tests` | **164 passés**, 0 échec |
| `bunx tsc --noEmit` | aucune erreur |
| `bunx playwright test` | **15 passés** |

Comportement observé dans le navigateur, joueur immobile :

```
t=0    green  sol 1.37   tourelle 1.08
t=2.5  player(mort)      — un seul missile, deux rebonds
```

Le violet traverse l'arène pour traquer, le cendre garde ses distances, le brun et le vert ne bougent jamais, et un brun hors de portée reste inerte.

Les tests couvrent notamment : conformité des profils aux relevés, tracé de trajectoire et comptage des segments, solution directe, solution à un rebond derrière un mur, absence de solution sans rebond autorisé, rejet d'une trajectoire passant sur un allié, marge de sortie de canon, tir effectif du brun vers le joueur, kill du vert à travers un mur, absence de suicide sur 40 s pour les profils à rebonds, immobilité stricte du brun et du vert, non-agression entre tanks de l'IA, silence hors de portée, respect du quota d'obus, esquive perpendiculaire, et déterminisme d'une bataille à quatre tanks rejouée.
