### PR TITLE
feat(tuning): panneau de calibration en direct et garde anti-valeurs magiques

### DIFF
--- a/e2e/tuning-panel.spec.ts
+++ b/e2e/tuning-panel.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from '@playwright/test';
+
+// La déclaration de `window.__tanks` vit dans src/client/debug-bridge.ts.
+import '../src/client/debug-bridge';
+
+type Page = import('@playwright/test').Page;
+
+/**
+ * Le panneau de calibration.
+ *
+ * Ce qu'on vérifie ici, c'est le circuit complet : un curseur déplacé doit
+ * atteindre la table de réglages, et la table de réglages doit atteindre la
+ * simulation **sans rechargement**. C'est toute la raison d'être de l'outil —
+ * un panneau qui n'agirait qu'au prochain démarrage ne servirait à rien pour
+ * comparer deux sensations.
+ */
+
+const PANEL = '.tuning-panel';
+
+/** Ouvre le panneau et attend qu'il soit visible. */
+async function openPanel(page: Page): Promise<void> {
+  await page.keyboard.press('Backquote');
+  await expect(page.locator(PANEL)).toBeVisible();
+}
+
+/** Déplace un curseur repéré par le libellé de sa ligne. */
+async function setKnob(page: Page, label: string, value: number): Promise<void> {
+  const slider = page
+    .locator('.tuning-knob')
+    .filter({ has: page.getByText(label, { exact: true }) })
+    .locator('input[type=range]');
+
+  await slider.fill(String(value));
+  // `fill` ne déclenche pas `input` sur tous les navigateurs : on le force.
+  await slider.dispatchEvent('input');
+}
+
+test('la touche ~ ouvre et referme le panneau', async ({ page }) => {
+  await page.goto('/?bac=1&calme=1');
+  await page.waitForFunction(() => window.__tanks !== undefined);
+
+  // Fermé au démarrage : le panneau ne doit pas s'imposer à qui veut jouer.
+  await expect(page.locator(PANEL)).toBeHidden();
+
+  await openPanel(page);
+  await page.keyboard.press('Backquote');
+  await expect(page.locator(PANEL)).toBeHidden();
+});
+
+test('un curseur modifie la simulation en direct', async ({ page }) => {
+  await page.goto('/?bac=1&calme=1');
+  await page.waitForFunction(() => window.__tanks !== undefined);
+  await openPanel(page);
+
+  const before = await page.evaluate(() => window.__tanks!.tuning.tank.speedTilesPerSecond);
+
+  // Le curseur est gradué en secondes de traversée : plus de secondes, donc
+  // moins de tuiles par seconde.
+  await setKnob(page, 'Traversée de l’arène', 14);
+
+  const after = await page.evaluate(() => window.__tanks!.tuning.tank.speedTilesPerSecond);
+
+  expect(after).toBeLessThan(before);
+  // Quatorze secondes pour 23 tuiles : la conversion doit tomber juste.
+  expect(after).toBeCloseTo(23 / 14, 3);
+});
+
+test('le tank ralentit réellement après le réglage', async ({ page }) => {
+  await page.goto('/?bac=1&calme=1');
+  await page.waitForFunction(() => window.__tanks !== undefined);
+
+  /** Distance parcourue vers la droite en une seconde de temps réel. */
+  const runRight = async (): Promise<number> => {
+    const start = await page.evaluate(() => window.__tanks!.world.tanks[0]!.x);
+    await page.keyboard.down('ArrowLeft');
+    await page.waitForTimeout(700);
+    await page.keyboard.up('ArrowLeft');
+    const end = await page.evaluate(() => window.__tanks!.world.tanks[0]!.x);
+    return start - end;
+  };
+
+  const atFullSpeed = await runRight();
+  expect(atFullSpeed).toBeGreaterThan(0.5);
+
+  await openPanel(page);
+  await setKnob(page, 'Traversée de l’arène', 20);
+  await page.keyboard.press('Backquote');
+
+  const atSlowSpeed = await runRight();
+
+  // Sept secondes de traversée contre vingt : le tank doit couvrir nettement
+  // moins de terrain dans le même temps, sans rechargement de la page.
+  expect(atSlowSpeed).toBeLessThan(atFullSpeed * 0.6);
+});
+
+test('l\'export reprend les mesures et les valeurs courantes', async ({ page }) => {
+  await page.goto('/?bac=1&calme=1');
+  await page.waitForFunction(() => window.__tanks !== undefined);
+  await openPanel(page);
+
+  await setKnob(page, 'Mèche', 5);
+
+  const exported = await page.locator('.tuning-export').inputValue();
+  const parsed = JSON.parse(exported) as {
+    mesures: Record<string, number>;
+    tuning: { mine: { fuseSeconds: number } };
+    profiles: { player: { turretRateRadiansPerSecond: unknown } };
+  };
+
+  expect(parsed.tuning.mine.fuseSeconds).toBe(5);
+  // Les temps de traversée sont les grandeurs chronométrables : ce sont elles
+  // qu'on relit pour comparer au jeu original.
+  expect(parsed.mesures['traverseeObusSecondes']).toBeCloseTo(4, 2);
+  expect(parsed.mesures['traverseeMissileSecondes']).toBeCloseTo(2, 2);
+  // `JSON.stringify` transforme Infinity en `null` : l'export doit le préserver,
+  // sinon la valeur recopiée serait fausse.
+  expect(parsed.profiles.player.turretRateRadiansPerSecond).toBe('Infinity');
+});
+
+test('changer de couleur remplace la section de profil', async ({ page }) => {
+  await page.goto('/?bac=1&calme=1');
+  await page.waitForFunction(() => window.__tanks !== undefined);
+  await openPanel(page);
+
+  await expect(page.getByRole('heading', { name: 'Profil — brown' })).toBeVisible();
+
+  await page.locator('.tuning-profile-picker select').selectOption('green');
+  await expect(page.getByRole('heading', { name: 'Profil — green' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Profil — brown' })).toBeHidden();
+
+  // Le profil du joueur n'expose ni tourelle ni portée : elles valent l'infini,
+  // qu'un curseur ne sait pas représenter.
+  await page.locator('.tuning-profile-picker select').selectOption('player');
+  await expect(page.getByText('Rotation de tourelle', { exact: true })).toBeHidden();
+  await expect(page.getByText('Portée de détection', { exact: true })).toBeHidden();
+});
+
+test('les calques de débogage se dessinent sans erreur', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  await page.goto('/?bac=1&calme=1');
+  await page.waitForFunction(() => window.__tanks !== undefined);
+  await openPanel(page);
+
+  for (const option of ['hitboxes', 'trajectories', 'blastRadii']) {
+    await page.locator(`input[data-debug-option="${option}"]`).check();
+  }
+
+  // Un obus en vol, pour que le calque de trajectoire ait quelque chose à tracer.
+  await page.keyboard.press('Backquote');
+  await page.locator('#game').click({ position: { x: 100, y: 300 } });
+  await page.waitForTimeout(400);
+
+  const drewSomething = await page.evaluate(
+    () => (window.__tanks?.world.shells.length ?? 0) >= 0,
+  );
+
+  expect(drewSomething).toBe(true);
+  expect(errors).toEqual([]);
+});

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -12,6 +12,8 @@
  *   ?mission=N         la campagne, à partir de la mission N
  *   ?bac=1             le terrain d'essai des tests bout-en-bout
  *   ?bac=1&calme=1     le même, sans ennemis
+ *
+ * La touche `~` ouvre le panneau de calibration, dans tous les modes.
  */
 
 import { TICK_RATE } from '@core/tick';
@@ -26,6 +28,7 @@ import { startGameLoop } from './loop';
 import { BOARD_BOTTOM_BAND_PX, Canvas2DRenderer } from './render/canvas2d/Canvas2DRenderer';
 import type { Session } from './session';
 import { drawHud } from './ui/hud';
+import { TuningPanel } from './ui/tuning-panel';
 
 /**
  * Récupère le canevas.
@@ -118,7 +121,7 @@ function drawDiagnostics(ctx: CanvasRenderingContext2D): void {
 
   ctx.fillStyle = '#b9a98c';
   ctx.textAlign = 'left';
-  ctx.fillText('ZQSD · souris viser · clic tirer · clic droit miner', 14, middle);
+  ctx.fillText('ZQSD · souris viser · clic tirer · clic droit miner · ~ réglages', 14, middle);
 
   // À droite, et volontairement court : les deux textes partagent une bande de
   // la largeur du plateau, et se chevauchaient dès que l'un des deux s'allongeait.
@@ -133,6 +136,17 @@ function drawDiagnostics(ctx: CanvasRenderingContext2D): void {
 
 const overlayCtx = canvas.getContext('2d');
 
+const panel = new TuningPanel();
+
+/**
+ * Coût moyen d'un pas de simulation, lissé.
+ *
+ * Mesuré ici et non dans `core/` : `performance.now()` y est proscrit, et à
+ * juste titre — une simulation qui lirait l'horloge ne serait plus déterministe.
+ */
+const SMOOTHING = 0.1;
+let msPerTick = 0;
+
 const bridge: TanksDebugBridge = { world: session.world, rates, tuning: TUNING };
 exposeDebugBridge(bridge);
 
@@ -145,13 +159,26 @@ startGameLoop({
     const tank = session.playerTank;
     if (tank) sampler.setAimOrigin(tank.x, tank.y);
 
+    const startedMs = performance.now();
     session.update(sampler.sample());
+    msPerTick += (performance.now() - startedMs - msPerTick) * SMOOTHING;
 
     // La campagne remplace son monde à chaque mission : la passerelle doit
     // suivre, sinon les tests bout-en-bout observeraient la mission précédente.
     bridge.world = session.world;
     const status = session.status();
     if (status) bridge.campaign = status;
+
+    const world = session.world;
+    panel.update({
+      tick: world.tick,
+      tanks: world.tanks.filter((each) => each.alive).length,
+      shells: world.shells.length,
+      mines: world.mines.length,
+      msPerTick,
+      ticksPerSecond: rates.ticksPerSecond,
+      framesPerSecond: rates.framesPerSecond,
+    });
   },
 
   render(alpha): void {
@@ -159,6 +186,7 @@ startGameLoop({
     sampleRates(performance.now());
 
     renderer.draw(session.world.grid, session.view(alpha));
+    renderer.drawDebug(session.world, panel.debug);
 
     if (overlayCtx) {
       const status = session.status();

--- a/src/client/render/Renderer.ts
+++ b/src/client/render/Renderer.ts
@@ -10,7 +10,8 @@
  * peut pas, même par accident, modifier l'état simulé.
  */
 
-import type { Grid } from '@core/state';
+import type { Grid, World } from '@core/state';
+import type { DebugOptions } from '../ui/tuning-panel';
 import type { RenderSnapshot } from './snapshots';
 
 export interface Renderer {
@@ -28,6 +29,18 @@ export interface Renderer {
 
   /** Dessine une frame. */
   draw(grid: Grid, view: RenderSnapshot): void;
+
+  /**
+   * Superpose les calques de débogage demandés par le panneau de calibration.
+   *
+   * Seule méthode à recevoir le `World` plutôt qu'un instantané, et c'est
+   * assumé : ces calques servent à vérifier ce que la simulation fait
+   * réellement. Une boîte de collision interpolée, décalée d'une fraction de
+   * pas par rapport à celle qui décide des impacts, ne prouverait rien.
+   *
+   * Elle ne lit jamais que l'état — la règle « le rendu ne modifie rien » tient.
+   */
+  drawDebug(world: World, options: Readonly<DebugOptions>): void;
 
   /**
    * Convertit des coordonnées de pointeur (repère de la fenêtre) en coordonnées

--- a/src/client/render/canvas2d/Canvas2DRenderer.ts
+++ b/src/client/render/canvas2d/Canvas2DRenderer.ts
@@ -7,10 +7,12 @@
  */
 
 import { TileKind } from '@core/state';
-import type { Grid } from '@core/state';
+import type { Grid, World } from '@core/state';
 import { TILE_SIZE_PX, TUNING } from '@core/tuning';
 import { tileAt } from '@core/grid';
 import { BLAST, BLOCKS, BOARD, SHELL, TANK_COLORS, darken, lighten } from '../palette';
+import type { DebugOptions } from '../../ui/tuning-panel';
+import { drawDebugOverlay } from './debug-overlay';
 import type { Renderer } from '../Renderer';
 import type {
   ExplosionView,
@@ -128,6 +130,23 @@ export class Canvas2DRenderer implements Renderer {
       this.#drawExplosion(explosion);
     }
 
+    this.#ctx.restore();
+  }
+
+  /**
+   * Superpose les calques de débogage.
+   *
+   * Méthode distincte de `draw`, et prenant le `World` et non un instantané :
+   * ces calques servent à vérifier ce que la simulation fait réellement, donc
+   * ils lisent la source. La transformation du plateau est réappliquée ici,
+   * puisqu'elle appartient au renderer.
+   */
+  drawDebug(world: World, options: Readonly<DebugOptions>): void {
+    if (!options.hitboxes && !options.trajectories && !options.blastRadii) return;
+
+    this.#ctx.save();
+    this.#ctx.translate(0, BOARD_TOP_BAND_PX);
+    drawDebugOverlay(this.#ctx, world, options);
     this.#ctx.restore();
   }
 

--- a/src/client/render/canvas2d/debug-overlay.ts
+++ b/src/client/render/canvas2d/debug-overlay.ts
@@ -1,0 +1,140 @@
+/**
+ * Calques de débogage : boîtes de collision, trajectoires prévues, rayons de souffle.
+ *
+ * Ils lisent le `World` réel et non un instantané interpolé. C'est une entorse
+ * assumée à la règle « le rendu ne voit que des instantanés », et elle est
+ * volontaire : ces calques servent précisément à vérifier ce que la simulation
+ * fait, pas ce qu'on en montre. Une boîte de collision interpolée, décalée d'une
+ * fraction de pas par rapport à celle qui décide réellement des impacts, ne
+ * prouverait rien.
+ *
+ * Ils ne modifient jamais l'état — le module n'appelle que des lectures.
+ */
+
+import { blocksTank, tileAt } from '@core/grid';
+import type { World } from '@core/state';
+import { traceShellPath } from '@core/systems/ai/aiming';
+import { TILE_SIZE_PX, TUNING } from '@core/tuning';
+import type { DebugOptions } from '../../ui/tuning-panel';
+
+const COLORS = {
+  hitbox: 'rgba(120, 220, 255, 0.9)',
+  hitboxSolid: 'rgba(255, 120, 120, 0.55)',
+  trajectory: 'rgba(255, 220, 90, 0.9)',
+  trajectorySpent: 'rgba(255, 120, 60, 0.75)',
+  blast: 'rgba(255, 120, 60, 0.85)',
+};
+
+/** Trace un cercle en coordonnées monde. */
+function strokeCircle(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radiusTiles: number,
+): void {
+  ctx.beginPath();
+  ctx.arc(x * TILE_SIZE_PX, y * TILE_SIZE_PX, radiusTiles * TILE_SIZE_PX, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
+/**
+ * Dessine les calques demandés.
+ *
+ * Le contexte doit déjà être translaté sur l'origine du plateau : c'est le
+ * renderer qui détient cette transformation, ce module n'en connaît rien.
+ */
+export function drawDebugOverlay(
+  ctx: CanvasRenderingContext2D,
+  world: World,
+  options: Readonly<DebugOptions>,
+): void {
+  ctx.save();
+  ctx.lineWidth = 1;
+
+  if (options.hitboxes) drawHitboxes(ctx, world);
+  if (options.trajectories) drawTrajectories(ctx, world);
+  if (options.blastRadii) drawBlastRadii(ctx, world);
+
+  ctx.restore();
+}
+
+/**
+ * Boîtes des tanks, cercles des obus et des mines, et tuiles solides.
+ *
+ * Le châssis tourne à l'écran mais sa boîte reste alignée aux axes, comme dans
+ * l'original : c'est exactement ce que ce calque rend visible.
+ */
+function drawHitboxes(ctx: CanvasRenderingContext2D, world: World): void {
+  const half = TUNING.tank.sizeTiles / 2;
+
+  ctx.strokeStyle = COLORS.hitboxSolid;
+  for (let y = 0; y < world.grid.height; y++) {
+    for (let x = 0; x < world.grid.width; x++) {
+      if (!blocksTank(tileAt(world.grid, x, y))) continue;
+      ctx.strokeRect(x * TILE_SIZE_PX + 0.5, y * TILE_SIZE_PX + 0.5, TILE_SIZE_PX - 1, TILE_SIZE_PX - 1);
+    }
+  }
+
+  ctx.strokeStyle = COLORS.hitbox;
+
+  for (const tank of world.tanks) {
+    if (!tank.alive) continue;
+    ctx.strokeRect(
+      (tank.x - half) * TILE_SIZE_PX,
+      (tank.y - half) * TILE_SIZE_PX,
+      TUNING.tank.sizeTiles * TILE_SIZE_PX,
+      TUNING.tank.sizeTiles * TILE_SIZE_PX,
+    );
+  }
+
+  for (const shell of world.shells) {
+    strokeCircle(ctx, shell.x, shell.y, TUNING.shell.radiusTiles);
+  }
+
+  for (const mine of world.mines) {
+    strokeCircle(ctx, mine.x, mine.y, TUNING.mine.radiusTiles);
+  }
+}
+
+/**
+ * Chemin que chaque obus en vol suivra, rebonds restants compris.
+ *
+ * Le tracé réutilise `traceShellPath`, c'est-à-dire **exactement** la fonction
+ * dont l'IA se sert pour chercher ses angles. Ce calque montre donc ce que les
+ * ennemis calculent, et pas une seconde implémentation qui pourrait en diverger.
+ */
+function drawTrajectories(ctx: CanvasRenderingContext2D, world: World): void {
+  // Plus épais que les boîtes de collision : c'est la ligne qu'on suit du
+  // regard pour vérifier un angle, et un trait d'un pixel se perd sur le bois
+  // clair du plateau.
+  ctx.lineWidth = 2;
+
+  for (const shell of world.shells) {
+    const angle = Math.atan2(shell.vy, shell.vx);
+    const segments = traceShellPath(world.grid, shell.x, shell.y, angle, shell.bouncesLeft);
+
+    segments.forEach((segment, index) => {
+      // Le dernier tronçon est celui après lequel l'obus n'a plus de rebond :
+      // c'est là qu'il explosera, d'où la couleur distincte.
+      ctx.strokeStyle = index === segments.length - 1 ? COLORS.trajectorySpent : COLORS.trajectory;
+
+      ctx.beginPath();
+      ctx.moveTo(segment.x0 * TILE_SIZE_PX, segment.y0 * TILE_SIZE_PX);
+      ctx.lineTo(segment.x1 * TILE_SIZE_PX, segment.y1 * TILE_SIZE_PX);
+      ctx.stroke();
+    });
+  }
+}
+
+/** Portée du souffle de chaque mine, à comparer aux blocs qu'elle emportera. */
+function drawBlastRadii(ctx: CanvasRenderingContext2D, world: World): void {
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = COLORS.blast;
+  ctx.setLineDash([6, 4]);
+
+  for (const mine of world.mines) {
+    strokeCircle(ctx, mine.x, mine.y, TUNING.mine.blastRadiusTiles);
+  }
+
+  ctx.setLineDash([]);
+}

--- a/src/client/ui/knobs.ts
+++ b/src/client/ui/knobs.ts
@@ -1,0 +1,391 @@
+/**
+ * Description des réglages exposés par le panneau de calibration.
+ *
+ * Séparé du panneau lui-même parce que ce sont deux choses différentes : ici on
+ * dit **quoi** régler et dans quelles bornes, là-bas on dit **comment**
+ * l'afficher. Ajouter un réglage se fait donc en ajoutant une ligne à une
+ * liste, sans toucher au code d'interface.
+ *
+ * Chaque réglage lit et écrit directement dans `TUNING` ou `TANK_PROFILES` :
+ * il n'existe pas de copie intermédiaire à synchroniser, et une valeur modifiée
+ * prend effet au pas de simulation suivant.
+ */
+
+import type { TankColor } from '@core/state';
+import { REFERENCE_MEASUREMENTS, TILE_SIZE_PX, TUNING } from '@core/tuning';
+import { TANK_PROFILES } from '@core/systems/ai/profiles';
+
+/** Un réglage réglable, avec ses bornes d'affichage. */
+export interface Knob {
+  label: string;
+  /** Unité affichée à côté de la valeur. Vide pour un nombre pur. */
+  unit: string;
+  min: number;
+  max: number;
+  step: number;
+  get(): number;
+  set(value: number): void;
+  /** Précision d'affichage, en décimales. */
+  decimals: number;
+  /** Explication, affichée en info-bulle. */
+  hint?: string;
+}
+
+/** Un groupe de réglages affiché ensemble. */
+export interface KnobGroup {
+  title: string;
+  note?: string;
+  knobs: Knob[];
+}
+
+/* ── Fabriques ─────────────────────────────────────────────────────────── */
+
+/** Clés d'un objet dont la valeur est un nombre. */
+type NumericKeys<T> = {
+  [K in keyof T]-?: T[K] extends number ? K : never;
+}[keyof T];
+
+/**
+ * Réglage portant sur un champ numérique d'un objet.
+ *
+ * Le passage par une clé plutôt que par deux fermetures évite de répéter
+ * `get: () => x.y, set: (v) => { x.y = v; }` une quarantaine de fois — et donc
+ * d'écrire un jour un `get` qui ne lit pas le champ que son `set` écrit.
+ */
+function field<T extends object, K extends NumericKeys<T> & keyof T>(
+  target: T,
+  key: K,
+  options: Omit<Knob, 'get' | 'set' | 'decimals'> & { decimals?: number },
+): Knob {
+  // `NumericKeys` garantit déjà que le champ est un nombre ; le compilateur, lui,
+  // ne sait pas le propager jusqu'à l'affectation.
+  const numeric = target as Record<K, number>;
+
+  return {
+    ...options,
+    decimals: options.decimals ?? 2,
+    get: () => numeric[key],
+    set: (value) => {
+      numeric[key] = value;
+    },
+  };
+}
+
+/* ── Réglages globaux ──────────────────────────────────────────────────── */
+
+/**
+ * Vitesse réglée en **secondes de traversée d'arène**, et non en tuiles par
+ * seconde.
+ *
+ * C'est la grandeur qu'on sait mesurer sur l'original, chronomètre en main : le
+ * curseur s'ajuste donc dans la même unité que le relevé auquel on le compare.
+ */
+function crossingKnob(
+  label: string,
+  read: () => number,
+  write: (tilesPerSecond: number) => void,
+  hint: string,
+): Knob {
+  const widthTiles = REFERENCE_MEASUREMENTS.arenaWidthPx / TILE_SIZE_PX;
+
+  return {
+    label,
+    unit: 's',
+    min: 1,
+    max: 20,
+    step: 0.1,
+    decimals: 2,
+    hint,
+    get: () => widthTiles / read(),
+    set: (seconds) => write(widthTiles / seconds),
+  };
+}
+
+export function globalGroups(): KnobGroup[] {
+  return [
+    {
+      title: 'Tank du joueur',
+      note: 'Les temps de traversée sont les grandeurs réellement mesurées sur l’original.',
+      knobs: [
+        crossingKnob(
+          'Traversée de l’arène',
+          () => TUNING.tank.speedTilesPerSecond,
+          (value) => {
+            TUNING.tank.speedTilesPerSecond = value;
+          },
+          `Relevé : ${REFERENCE_MEASUREMENTS.tankCrossingSeconds} s pour ${REFERENCE_MEASUREMENTS.arenaWidthPx} px.`,
+        ),
+        field(TUNING.tank, 'turnRateRadiansPerSecond', {
+          label: 'Rotation du châssis',
+          unit: 'rad/s',
+          min: 1,
+          max: 30,
+          step: 0.1,
+          hint: 'Purement visuel : la boîte de collision ne tourne pas.',
+        }),
+        field(TUNING.tank, 'sizeTiles', {
+          label: 'Taille du châssis',
+          unit: 'tuiles',
+          min: 0.4,
+          max: 1.2,
+          step: 0.01,
+          hint: 'Côté de la boîte de collision. 25 px sur l’arène de référence.',
+        }),
+        field(TUNING.tank, 'maxActiveShells', {
+          label: 'Obus simultanés',
+          unit: '',
+          min: 1,
+          max: 10,
+          step: 1,
+          decimals: 0,
+        }),
+        field(TUNING.tank, 'maxActiveMines', {
+          label: 'Mines simultanées',
+          unit: '',
+          min: 0,
+          max: 6,
+          step: 1,
+          decimals: 0,
+        }),
+      ],
+    },
+    {
+      title: 'Obus',
+      knobs: [
+        crossingKnob(
+          'Traversée — obus normal',
+          () => TUNING.shell.normalSpeedTilesPerSecond,
+          (value) => {
+            TUNING.shell.normalSpeedTilesPerSecond = value;
+          },
+          `Relevé : ${REFERENCE_MEASUREMENTS.shellCrossingSeconds} s pour ${REFERENCE_MEASUREMENTS.arenaWidthPx} px.`,
+        ),
+        crossingKnob(
+          'Traversée — missile',
+          () => TUNING.shell.fastSpeedTilesPerSecond,
+          (value) => {
+            TUNING.shell.fastSpeedTilesPerSecond = value;
+          },
+          'Relevé : exactement deux fois plus rapide qu’un obus normal.',
+        ),
+        field(TUNING.shell, 'radiusTiles', {
+          label: 'Rayon',
+          unit: 'tuiles',
+          min: 0.02,
+          max: 0.4,
+          step: 0.01,
+        }),
+        field(TUNING.shell, 'cooldownSeconds', {
+          label: 'Délai entre deux tirs',
+          unit: 's',
+          min: 0,
+          max: 2,
+          step: 0.05,
+        }),
+        field(TUNING.shell, 'muzzleOffsetFactor', {
+          label: 'Sortie de canon',
+          unit: '×',
+          min: 0.3,
+          max: 1.2,
+          step: 0.05,
+          hint: 'En fraction de la taille du tank. Trop court, l’obus naît dans le châssis ; trop long, il franchit les murs minces.',
+        }),
+      ],
+    },
+    {
+      title: 'Mines',
+      note: '⚠ Aucune de ces valeurs n’est mesurée — les mines n’existaient pas dans l’ancienne version.',
+      knobs: [
+        field(TUNING.mine, 'fuseSeconds', {
+          label: 'Mèche',
+          unit: 's',
+          min: 0.5,
+          max: 10,
+          step: 0.1,
+        }),
+        field(TUNING.mine, 'blastRadiusTiles', {
+          label: 'Rayon du souffle',
+          unit: 'tuiles',
+          min: 0.5,
+          max: 6,
+          step: 0.1,
+        }),
+        field(TUNING.mine, 'blastDurationSeconds', {
+          label: 'Durée de l’explosion',
+          unit: 's',
+          min: 0.1,
+          max: 2,
+          step: 0.05,
+        }),
+        field(TUNING.mine, 'cooldownSeconds', {
+          label: 'Délai entre deux poses',
+          unit: 's',
+          min: 0,
+          max: 5,
+          step: 0.1,
+        }),
+        field(TUNING.mine, 'radiusTiles', {
+          label: 'Rayon de collision',
+          unit: 'tuiles',
+          min: 0.1,
+          max: 1,
+          step: 0.05,
+        }),
+      ],
+    },
+    {
+      title: 'IA — commun à toutes les couleurs',
+      knobs: [
+        field(TUNING.ai, 'aimToleranceRadians', {
+          label: 'Tolérance de visée',
+          unit: 'rad',
+          min: 0.01,
+          max: 0.5,
+          step: 0.01,
+          hint: 'Trop serré, la tourelle oscille sans tirer.',
+        }),
+        field(TUNING.ai, 'evasionHorizonSeconds', {
+          label: 'Anticipation d’esquive',
+          unit: 's',
+          min: 0,
+          max: 3,
+          step: 0.1,
+        }),
+        field(TUNING.ai, 'roamMinSeconds', {
+          label: 'Patrouille — durée min.',
+          unit: 's',
+          min: 0.1,
+          max: 5,
+          step: 0.1,
+        }),
+        field(TUNING.ai, 'roamMaxSeconds', {
+          label: 'Patrouille — durée max.',
+          unit: 's',
+          min: 0.1,
+          max: 10,
+          step: 0.1,
+        }),
+      ],
+    },
+  ];
+}
+
+/* ── Réglages d'une couleur ────────────────────────────────────────────── */
+
+/**
+ * Réglages du profil d'une couleur.
+ *
+ * Les champs non finis — la tourelle instantanée et la portée illimitée du
+ * joueur — sont volontairement absents : un curseur ne peut pas représenter
+ * l'infini, et le remplacer par une grande valeur finie changerait le
+ * comportement en douce.
+ */
+export function profileGroup(color: TankColor): KnobGroup {
+  const profile = TANK_PROFILES[color];
+
+  const knobs: Knob[] = [
+    field(profile, 'speedMultiplier', {
+      label: 'Vitesse',
+      unit: '× joueur',
+      min: 0,
+      max: 3,
+      step: 0.1,
+    }),
+    field(profile, 'maxActiveShells', {
+      label: 'Obus simultanés',
+      unit: '',
+      min: 1,
+      max: 10,
+      step: 1,
+      decimals: 0,
+    }),
+    field(profile, 'shellBounces', {
+      label: 'Rebonds par obus',
+      unit: '',
+      min: 0,
+      max: 4,
+      step: 1,
+      decimals: 0,
+    }),
+    field(profile, 'maxActiveMines', {
+      label: 'Mines simultanées',
+      unit: '',
+      min: 0,
+      max: 6,
+      step: 1,
+      decimals: 0,
+    }),
+    field(profile, 'fireIntervalSeconds', {
+      label: 'Cadence de tir',
+      unit: 's',
+      min: 0,
+      max: 8,
+      step: 0.1,
+    }),
+    field(profile, 'fireIntervalJitterSeconds', {
+      label: 'Irrégularité de cadence',
+      unit: 's',
+      min: 0,
+      max: 8,
+      step: 0.1,
+    }),
+    field(profile, 'aimErrorRadians', {
+      label: 'Cône d’erreur',
+      unit: 'rad',
+      min: 0,
+      max: 1.5,
+      step: 0.01,
+    }),
+    field(profile, 'plannedBounces', {
+      label: 'Rebonds envisagés',
+      unit: '',
+      min: 0,
+      max: 3,
+      step: 1,
+      decimals: 0,
+      hint: 'Nombre de rebonds que l’IA explore en cherchant un angle de tir.',
+    }),
+    field(profile, 'preferredRangeTiles', {
+      label: 'Distance recherchée',
+      unit: 'tuiles',
+      min: 0,
+      max: 15,
+      step: 0.5,
+    }),
+  ];
+
+  // Ajoutés seulement s'ils sont représentables — voir la note ci-dessus.
+  if (Number.isFinite(profile.turretRateRadiansPerSecond)) {
+    knobs.splice(
+      1,
+      0,
+      field(profile, 'turretRateRadiansPerSecond', {
+        label: 'Rotation de tourelle',
+        unit: 'rad/s',
+        min: 0.1,
+        max: 6,
+        step: 0.05,
+      }),
+    );
+  }
+
+  if (Number.isFinite(profile.detectionRangeTiles)) {
+    knobs.push(
+      field(profile, 'detectionRangeTiles', {
+        label: 'Portée de détection',
+        unit: 'tuiles',
+        min: 1,
+        max: 30,
+        step: 0.5,
+      }),
+    );
+  }
+
+  return {
+    title: `Profil — ${color}`,
+    ...(color === 'player'
+      ? { note: 'Tourelle instantanée et portée illimitée : non réglables.' }
+      : {}),
+    knobs,
+  };
+}

--- a/src/client/ui/style.css
+++ b/src/client/ui/style.css
@@ -34,3 +34,147 @@ canvas {
   /* Rendu net : le jeu est dessiné en pixels logiques, sans lissage parasite. */
   image-rendering: pixelated;
 }
+
+/* ─── Panneau de calibration (touche ~) ───────────────────────────────────
+ *
+ * Ancré à droite et scrollable : il compte une quarantaine de curseurs, et il
+ * doit rester utilisable sur une fenêtre courte sans repousser le plateau.
+ * `position: fixed` le sort du `place-items: center` du corps de page.
+ */
+
+.tuning-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+
+  width: min(360px, 100vw);
+  padding: 12px 14px 24px;
+  overflow-y: auto;
+
+  background: #1b1510;
+  border-left: 1px solid #3a2e22;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.tuning-panel[hidden] {
+  display: none;
+}
+
+.tuning-panel h2 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tuning-panel h3 {
+  margin: 16px 0 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #3a2e22;
+  font-size: 12px;
+  color: #e8c98a;
+}
+
+.tuning-stats {
+  margin: 0;
+  padding: 6px 8px;
+  background: #241c14;
+  border-radius: 3px;
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  /* Les deux lignes de chiffres arrivent séparées par un \n. */
+  white-space: pre-line;
+}
+
+.tuning-note {
+  margin: 0 0 6px;
+  color: #9c8b70;
+  font-size: 11px;
+}
+
+/* Le libellé occupe sa propre ligne, le curseur et la valeur la suivante.
+ * Tout sur une seule ligne, les noms un peu longs se faisaient tronquer — et
+ * un réglage dont on ne lit pas le nom ne sert à rien. */
+.tuning-knob {
+  display: grid;
+  grid-template-columns: 1fr 76px;
+  align-items: center;
+  gap: 2px 8px;
+  margin: 7px 0;
+}
+
+.tuning-knob-name {
+  grid-column: 1 / -1;
+}
+
+.tuning-knob-value {
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  text-align: right;
+  color: #e8dcc0;
+}
+
+.tuning-knob input[type='range'] {
+  width: 100%;
+  accent-color: #4a90d9;
+}
+
+.tuning-toggle,
+.tuning-profile-picker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0;
+}
+
+.tuning-profile-picker {
+  margin-top: 16px;
+}
+
+.tuning-profile-picker select {
+  flex: 1;
+  background: #241c14;
+  color: var(--ink);
+  border: 1px solid #3a2e22;
+  border-radius: 3px;
+  padding: 3px 4px;
+  font: inherit;
+}
+
+.tuning-panel button {
+  margin-bottom: 6px;
+  padding: 4px 12px;
+  background: #3a2e22;
+  color: var(--ink);
+  border: 1px solid #564534;
+  border-radius: 3px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.tuning-panel button:hover {
+  background: #4a3b2c;
+}
+
+.tuning-export {
+  width: 100%;
+  height: 160px;
+  background: #120e0a;
+  color: #9c8b70;
+  border: 1px solid #3a2e22;
+  border-radius: 3px;
+  padding: 6px;
+  font-family: ui-monospace, monospace;
+  font-size: 10px;
+  resize: vertical;
+}
+
+/* Le plateau est centré par la grille du corps de page : une marge à droite
+ * suffit à le décaler quand le panneau s'ouvre, sans toucher au canevas. */
+body.panneau-ouvert {
+  padding-right: min(360px, 100vw);
+}

--- a/src/client/ui/tuning-panel.ts
+++ b/src/client/ui/tuning-panel.ts
@@ -1,0 +1,376 @@
+/**
+ * Panneau de calibration, ouvert par la touche `~`.
+ *
+ * ─── Pourquoi cet outil existe ───────────────────────────────────────────────
+ *
+ * Les constantes exactes du jeu Wii ne sont documentées nulle part. La seule
+ * méthode honnête est donc : partir des temps de traversée mesurés — les seuls
+ * faits observables — puis ajuster le reste **au ressenti, manette en main**.
+ *
+ * Ce panneau est ce qui rend cette seconde étape praticable. Sans lui, ajuster
+ * une valeur voudrait dire éditer un fichier, recompiler, relancer une partie,
+ * et essayer de se souvenir de la sensation d'il y a trente secondes. Avec lui,
+ * on compare deux réglages en trois secondes, curseur en main.
+ *
+ * ─── Ce qu'il n'est pas ──────────────────────────────────────────────────────
+ *
+ * Il n'introduit **aucune** valeur nouvelle : il ne fait qu'exposer `TUNING` et
+ * `TANK_PROFILES`, qui restent la seule source de vérité. Ce qu'on retient se
+ * recopie dans la source par l'export JSON — le panneau ne persiste rien.
+ *
+ * ⚠ Modifier un réglage en cours de partie rompt le déterminisme de cette
+ * partie-là : deux clients n'auraient plus la même table. C'est sans importance
+ * en solo, et le serveur (#13) transmettra la sienne à la connexion — le
+ * panneau y sera donc un outil de mise au point, pas de jeu.
+ *
+ * Le panneau est en DOM et non dessiné dans le canevas, contrairement au HUD :
+ * il lui faut des curseurs, du texte sélectionnable et une zone de copie. Le
+ * navigateur fait tout ça mieux qu'un `fillText`, et rien de tout cela n'a à
+ * rester aligné au plateau.
+ */
+
+import type { TankColor } from '@core/state';
+import { TANK_PROFILES } from '@core/systems/ai/profiles';
+import { REFERENCE_MEASUREMENTS, TILE_SIZE_PX, TUNING } from '@core/tuning';
+import { globalGroups, profileGroup } from './knobs';
+import type { Knob, KnobGroup } from './knobs';
+
+/** Couleurs proposées dans le sélecteur de profil. */
+const PROFILE_COLORS = Object.keys(TANK_PROFILES) as TankColor[];
+
+/** Chiffres vivants affichés en tête du panneau. */
+export interface PanelStats {
+  tick: number;
+  /** Tanks encore en vie. */
+  tanks: number;
+  shells: number;
+  mines: number;
+  /** Temps de calcul moyen d'un pas de simulation, en millisecondes. */
+  msPerTick: number;
+  ticksPerSecond: number;
+  framesPerSecond: number;
+}
+
+/** Ce que le panneau donne à voir en plus des réglages. */
+export interface DebugOptions {
+  /** Boîtes de collision des tanks, des obus et des mines. */
+  hitboxes: boolean;
+  /** Trajectoires prévues des obus en vol, rebonds compris. */
+  trajectories: boolean;
+  /** Rayon du souffle de chaque mine posée. */
+  blastRadii: boolean;
+}
+
+export const DEFAULT_DEBUG_OPTIONS: DebugOptions = {
+  hitboxes: false,
+  trajectories: false,
+  blastRadii: false,
+};
+
+/** Touche d'ouverture. `Backquote` est la touche `~` / `²` selon la disposition. */
+const TOGGLE_KEY = 'Backquote';
+
+export class TuningPanel {
+  readonly #root: HTMLElement;
+  readonly #statsLine: HTMLElement;
+  readonly #profileHost: HTMLElement;
+  readonly #exportArea: HTMLTextAreaElement;
+
+  /**
+   * Rafraîchisseurs des curseurs, appelés quand les valeurs changent hors panneau.
+   *
+   * Deux listes et non une : la section de profil est reconstruite à chaque
+   * changement de couleur, et ses rafraîchisseurs doivent partir avec elle.
+   * Mélangés aux autres, ils pointeraient sur des éléments détachés du document
+   * et fuiraient à chaque changement.
+   */
+  readonly #globalRefreshers: Array<() => void> = [];
+  #profileRefreshers: Array<() => void> = [];
+
+  readonly #debug: DebugOptions = { ...DEFAULT_DEBUG_OPTIONS };
+
+  #open = false;
+
+  constructor(host: HTMLElement = document.body) {
+    this.#root = document.createElement('aside');
+    this.#root.className = 'tuning-panel';
+    this.#root.hidden = true;
+    // Le panneau est un outil, pas du contenu : il ne doit pas être lu par une
+    // technologie d'assistance comme s'il faisait partie du jeu.
+    this.#root.setAttribute('role', 'group');
+    this.#root.setAttribute('aria-label', 'Panneau de calibration');
+
+    const title = document.createElement('h2');
+    title.textContent = 'Calibration';
+    this.#root.append(title);
+
+    this.#statsLine = document.createElement('p');
+    this.#statsLine.className = 'tuning-stats';
+    this.#root.append(this.#statsLine);
+
+    // La zone d'export est créée en premier bien qu'affichée en dernier :
+    // construire une section de réglages écrit dedans, et un champ pas encore
+    // initialisé ferait échouer tout le démarrage du client.
+    this.#exportArea = document.createElement('textarea');
+    this.#exportArea.className = 'tuning-export';
+    this.#exportArea.readOnly = true;
+    this.#exportArea.spellcheck = false;
+
+    this.#root.append(this.#buildDebugToggles());
+
+    for (const group of globalGroups()) {
+      this.#root.append(this.#buildGroup(group, this.#globalRefreshers));
+    }
+
+    this.#profileHost = document.createElement('div');
+    this.#root.append(this.#buildProfileSelector(), this.#profileHost);
+    this.#showProfile(PROFILE_COLORS[1] ?? 'brown');
+
+    this.#root.append(this.#buildExport());
+
+    host.append(this.#root);
+    window.addEventListener('keydown', this.#onKeyDown);
+  }
+
+  get open(): boolean {
+    return this.#open;
+  }
+
+  /** Options d'affichage de débogage. Lues à chaque frame par le renderer. */
+  get debug(): Readonly<DebugOptions> {
+    return this.#debug;
+  }
+
+  toggle(): void {
+    this.#open = !this.#open;
+    this.#root.hidden = !this.#open;
+
+    // Le panneau est en position fixe : sans cette marque, il recouvrirait le
+    // bord droit du plateau, et le HUD avec. La classe décale la page.
+    document.body.classList.toggle('panneau-ouvert', this.#open);
+
+    // Les curseurs peuvent être périmés si une valeur a changé ailleurs.
+    if (this.#open) this.#refreshAll();
+  }
+
+  /** Met à jour les chiffres vivants. Sans effet quand le panneau est fermé. */
+  update(stats: PanelStats): void {
+    if (!this.#open) return;
+
+    this.#statsLine.textContent =
+      `pas ${stats.tick} · ${stats.tanks} tanks · ${stats.shells} obus · ${stats.mines} mines\n` +
+      `${stats.msPerTick.toFixed(2)} ms/pas · ${stats.ticksPerSecond} pas/s · ${stats.framesPerSecond} img/s`;
+  }
+
+  dispose(): void {
+    window.removeEventListener('keydown', this.#onKeyDown);
+    document.body.classList.remove('panneau-ouvert');
+    this.#root.remove();
+  }
+
+  /* ── Construction ─────────────────────────────────────────────────────── */
+
+  readonly #onKeyDown = (event: KeyboardEvent): void => {
+    if (event.code !== TOGGLE_KEY) return;
+    event.preventDefault();
+    this.toggle();
+  };
+
+  #buildGroup(group: KnobGroup, refreshers: Array<() => void>): HTMLElement {
+    const section = document.createElement('section');
+
+    const heading = document.createElement('h3');
+    heading.textContent = group.title;
+    section.append(heading);
+
+    if (group.note) {
+      const note = document.createElement('p');
+      note.className = 'tuning-note';
+      note.textContent = group.note;
+      section.append(note);
+    }
+
+    for (const knob of group.knobs) section.append(this.#buildKnob(knob, refreshers));
+    return section;
+  }
+
+  #buildKnob(knob: Knob, refreshers: Array<() => void>): HTMLElement {
+    const row = document.createElement('label');
+    row.className = 'tuning-knob';
+    if (knob.hint) row.title = knob.hint;
+
+    const name = document.createElement('span');
+    name.className = 'tuning-knob-name';
+    name.textContent = knob.label;
+
+    const readout = document.createElement('output');
+    readout.className = 'tuning-knob-value';
+
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.min = String(knob.min);
+    slider.max = String(knob.max);
+    slider.step = String(knob.step);
+
+    const show = (): void => {
+      const value = knob.get();
+      readout.textContent = `${value.toFixed(knob.decimals)}${knob.unit ? ` ${knob.unit}` : ''}`;
+    };
+
+    const refresh = (): void => {
+      slider.value = String(knob.get());
+      show();
+    };
+
+    slider.addEventListener('input', () => {
+      knob.set(Number(slider.value));
+      show();
+      this.#updateExport();
+    });
+
+    refresh();
+    refreshers.push(refresh);
+
+    row.append(name, slider, readout);
+    return row;
+  }
+
+  #buildDebugToggles(): HTMLElement {
+    const section = document.createElement('section');
+
+    const heading = document.createElement('h3');
+    heading.textContent = 'Affichage de débogage';
+    section.append(heading);
+
+    const toggles: Array<[keyof DebugOptions, string, string]> = [
+      ['hitboxes', 'Boîtes de collision', 'Le châssis ne tourne pas : sa boîte reste alignée aux axes.'],
+      ['trajectories', 'Trajectoires prévues', 'Chemin de chaque obus en vol, rebonds restants compris.'],
+      ['blastRadii', 'Rayons de souffle', 'Portée de l’explosion de chaque mine posée.'],
+    ];
+
+    for (const [key, label, hint] of toggles) {
+      const row = document.createElement('label');
+      row.className = 'tuning-toggle';
+      row.title = hint;
+
+      const box = document.createElement('input');
+      box.type = 'checkbox';
+      box.checked = this.#debug[key];
+      box.dataset['debugOption'] = key;
+      box.addEventListener('change', () => {
+        this.#debug[key] = box.checked;
+      });
+
+      const text = document.createElement('span');
+      text.textContent = label;
+
+      row.append(box, text);
+      section.append(row);
+    }
+
+    return section;
+  }
+
+  #buildProfileSelector(): HTMLElement {
+    const row = document.createElement('label');
+    row.className = 'tuning-profile-picker';
+
+    const text = document.createElement('span');
+    text.textContent = 'Couleur';
+
+    const select = document.createElement('select');
+    for (const color of PROFILE_COLORS) {
+      const option = document.createElement('option');
+      option.value = color;
+      option.textContent = color;
+      select.append(option);
+    }
+    select.value = PROFILE_COLORS[1] ?? 'brown';
+    select.addEventListener('change', () => this.#showProfile(select.value as TankColor));
+
+    row.append(text, select);
+    return row;
+  }
+
+  /**
+   * Remplace la section de profil.
+   *
+   * Une couleur à la fois : dix profils de quatorze réglages feraient cent
+   * quarante curseurs à l'écran, où l'on ne trouverait plus rien.
+   */
+  #showProfile(color: TankColor): void {
+    this.#profileRefreshers = [];
+    this.#profileHost.replaceChildren(
+      this.#buildGroup(profileGroup(color), this.#profileRefreshers),
+    );
+    this.#updateExport();
+  }
+
+  #buildExport(): HTMLElement {
+    const section = document.createElement('section');
+
+    const heading = document.createElement('h3');
+    heading.textContent = 'Export';
+    section.append(heading);
+
+    const note = document.createElement('p');
+    note.className = 'tuning-note';
+    note.textContent =
+      'À recopier dans src/core/tuning.ts et systems/ai/profiles.ts. ' +
+      'Le bloc « mesures » rappelle les grandeurs chronométrables : ce sont elles ' +
+      'qui font foi, les vitesses en tuiles/s n’en sont que la traduction. ' +
+      '« Infinity » vaut Number.POSITIVE_INFINITY.';
+    section.append(note);
+
+    const copy = document.createElement('button');
+    copy.type = 'button';
+    copy.textContent = 'Copier';
+    copy.addEventListener('click', () => {
+      this.#updateExport();
+      // `select()` avant l'API presse-papiers : celle-ci exige un contexte
+      // sécurisé, et le mode développement n'en est pas toujours un.
+      this.#exportArea.select();
+      void navigator.clipboard?.writeText(this.#exportArea.value).catch(() => {
+        /* La sélection reste, un Ctrl+C manuel suffit. */
+      });
+    });
+
+    section.append(copy, this.#exportArea);
+    this.#updateExport();
+    return section;
+  }
+
+  #updateExport(): void {
+    const widthTiles = REFERENCE_MEASUREMENTS.arenaWidthPx / TILE_SIZE_PX;
+    const crossing = (tilesPerSecond: number): number =>
+      Number((widthTiles / tilesPerSecond).toFixed(3));
+
+    // `JSON.stringify` transforme silencieusement Infinity en `null`, ce qui
+    // ferait recopier une valeur fausse. On l'écrit en toutes lettres.
+    const keepInfinities = (_key: string, value: unknown): unknown =>
+      typeof value === 'number' && !Number.isFinite(value) ? String(value) : value;
+
+    this.#exportArea.value = JSON.stringify(
+      {
+        // En tête, parce que c'est la seule partie qui se vérifie chronomètre
+        // en main sur le jeu original.
+        mesures: {
+          largeurArenePx: REFERENCE_MEASUREMENTS.arenaWidthPx,
+          traverseeTankSecondes: crossing(TUNING.tank.speedTilesPerSecond),
+          traverseeObusSecondes: crossing(TUNING.shell.normalSpeedTilesPerSecond),
+          traverseeMissileSecondes: crossing(TUNING.shell.fastSpeedTilesPerSecond),
+        },
+        tuning: TUNING,
+        profiles: TANK_PROFILES,
+      },
+      keepInfinities,
+      2,
+    );
+  }
+
+  #refreshAll(): void {
+    for (const refresh of this.#globalRefreshers) refresh();
+    for (const refresh of this.#profileRefreshers) refresh();
+    this.#updateExport();
+  }
+}

--- a/src/core/grid.ts
+++ b/src/core/grid.ts
@@ -16,6 +16,16 @@ import type { Grid } from './state.js';
  * Hors de la grille, on répond « incassable » : le monde est clos, et cette
  * convention évite d'avoir à tester les bornes partout ailleurs.
  */
+/**
+ * Plafond d'itérations du lancer de rayon, en multiples du demi-périmètre.
+ *
+ * Paramètre de méthode, non de gameplay : une traversée en diagonale coûte au
+ * plus `largeur + hauteur` pas, et le facteur laisse la marge nécessaire aux
+ * directions rasantes. Il n'existe que pour qu'une direction dégénérée ne
+ * boucle pas indéfiniment.
+ */
+const RAY_STEP_BUDGET_FACTOR = 4;
+
 export function tileAt(grid: Grid, tileX: number, tileY: number): TileKind {
   if (tileX < 0 || tileY < 0 || tileX >= grid.width || tileY >= grid.height) {
     return TileKind.Indestructible;
@@ -392,7 +402,7 @@ export function raycastGrid(
       : (dirY > 0 ? tileY + 1 - originY : originY - tileY) * spanY;
 
   // Garde-fou : une direction non normalisée ou dégénérée ne doit pas boucler.
-  const maxSteps = 4 * (grid.width + grid.height);
+  const maxSteps = RAY_STEP_BUDGET_FACTOR * (grid.width + grid.height);
 
   for (let step = 0; step < maxSteps; step++) {
     let distance: number;

--- a/src/core/systems/ai/brain.ts
+++ b/src/core/systems/ai/brain.ts
@@ -33,8 +33,6 @@ import type { TankProfile } from './profiles.js';
  */
 const AIM_PERIOD_TICKS = 12;
 
-/** Écart de visée toléré avant de tirer, en radians. */
-const AIM_TOLERANCE_RADIANS = 0.08;
 
 /** État d'IA neutre, attribué à tout tank non piloté par un joueur. */
 export function createAiState(): TankAiState {
@@ -130,7 +128,13 @@ function updateRoaming(world: World, tank: Tank, ai: TankAiState): void {
   }
 
   ai.roamAngle = nextRange(world.rng, 0, Math.PI * 2);
-  ai.roamTicks = Math.round(nextRange(world.rng, 30, 120));
+  ai.roamTicks = Math.round(
+    nextRange(
+      world.rng,
+      secondsToTicks(TUNING.ai.roamMinSeconds),
+      secondsToTicks(TUNING.ai.roamMaxSeconds),
+    ),
+  );
 }
 
 /** Construit l'intention d'un tank de l'IA pour ce pas. */
@@ -166,7 +170,8 @@ export function decideAiInput(world: World, tank: Tank): InputCommand {
   // ── Tir ──
   // On ne tire qu'une fois la tourelle effectivement alignée : sinon l'obus
   // partirait dans la direction où le canon se trouve, pas où il vise.
-  const aligned = Math.abs(normalizeAngle(aim - tank.turretAngle)) <= AIM_TOLERANCE_RADIANS;
+  const aligned =
+    Math.abs(normalizeAngle(aim - tank.turretAngle)) <= TUNING.ai.aimToleranceRadians;
   const fire = ai.solutionAngle !== null && aligned && ai.fireCooldownTicks === 0;
 
   if (fire) {

--- a/src/core/systems/ai/threat.ts
+++ b/src/core/systems/ai/threat.ts
@@ -10,15 +10,20 @@ import { TUNING } from '../../tuning.js';
 import type { Shell, Tank } from '../../state.js';
 
 /**
- * Anticipation de l'esquive, en secondes.
+ * Largeur du couloir considéré comme menaçant, en tuiles.
  *
- * Un obus qui arrivera dans plus d'une seconde ne mérite pas encore de
- * réaction : le tank aurait le temps de se décaler puis de revenir dedans.
+ * Dérivée de la taille du tank plutôt que réglable à part : un obus est
+ * menaçant s'il passe dans l'emprise du châssis, pas à une distance arbitraire.
+ * L'anticipation, elle, se règle — voir `TUNING.ai.evasionHorizonSeconds`.
+ *
+ * Une fonction et non une constante de module : `const X = TUNING.…` fige la
+ * valeur au chargement, et le panneau de calibration aurait beau modifier la
+ * taille du châssis, ce couloir-ci serait resté à sa valeur de départ. Un test
+ * de garde interdit désormais cette forme.
  */
-const REACTION_HORIZON_SECONDS = 1;
-
-/** Largeur du couloir considéré comme menaçant, en tuiles. */
-const THREAT_CORRIDOR_TILES = TUNING.tank.sizeTiles;
+function threatCorridorTiles(): number {
+  return TUNING.tank.sizeTiles;
+}
 
 /** Direction dans laquelle s'écarter, ou `null` si rien ne menace. */
 export interface EvasionVector {
@@ -55,11 +60,11 @@ export function findEvasion(tank: Tank, shells: readonly Shell[]): EvasionVector
     // Derrière l'obus, ou trop loin devant pour être une menace immédiate.
     if (along <= 0) continue;
     const timeToReach = along / speed;
-    if (timeToReach > REACTION_HORIZON_SECONDS || timeToReach >= closestTime) continue;
+    if (timeToReach > TUNING.ai.evasionHorizonSeconds || timeToReach >= closestTime) continue;
 
     // Écart latéral : l'obus passe-t-il assez près pour toucher ?
     const lateral = toTankX * -dirY + toTankY * dirX;
-    if (Math.abs(lateral) > THREAT_CORRIDOR_TILES) continue;
+    if (Math.abs(lateral) > threatCorridorTiles()) continue;
 
     closestTime = timeToReach;
     // On s'écarte perpendiculairement, du côté où l'on est déjà. Fuir dans

--- a/src/core/systems/shells.ts
+++ b/src/core/systems/shells.ts
@@ -62,7 +62,7 @@ export function fireShell(world: World, tank: Tank): Shell | null {
   // L'obus naît au bout du canon. Si ce point tombe dans un mur — canon collé
   // contre un bloc — on le fait naître au centre du tank : le faire apparaître
   // à l'intérieur du mur donnerait un rebond dans une direction arbitraire.
-  const muzzle = TUNING.tank.sizeTiles * 0.55;
+  const muzzle = TUNING.tank.sizeTiles * TUNING.shell.muzzleOffsetFactor;
   const half = TUNING.shell.radiusTiles;
   let x = tank.x + dirX * muzzle;
   let y = tank.y + dirY * muzzle;

--- a/src/core/tuning.ts
+++ b/src/core/tuning.ts
@@ -74,8 +74,14 @@ export const REFERENCE_MEASUREMENTS = {
 /** Forme de la table de réglages. Mutable : le panneau de #10 l'édite en direct. */
 export interface Tuning {
   tank: {
-    /** Côté de la boîte de collision, en tuiles. */
-    readonly sizeTiles: number;
+    /**
+     * Côté de la boîte de collision, en tuiles.
+     *
+     * Modifiable comme le reste : le panneau de calibration l'expose, parce que
+     * la largeur du châssis décide si un tank passe ou non dans un couloir
+     * d'une tuile — ce qui se ressent immédiatement en jeu.
+     */
+    sizeTiles: number;
     /** Vitesse de déplacement de référence (le joueur), en tuiles/seconde. */
     speedTilesPerSecond: number;
     /** Vitesse de rotation du corps vers la direction visée, en radians/seconde. */
@@ -94,6 +100,13 @@ export interface Tuning {
     fastSpeedTilesPerSecond: number;
     /** Délai minimal entre deux tirs du joueur, en secondes. */
     cooldownSeconds: number;
+    /**
+     * Distance du canon au centre du tank, en fraction de la taille du tank.
+     *
+     * Détermine où naît l'obus. Trop court, il apparaît dans le châssis ; trop
+     * long, il franchit les murs minces au moment du tir.
+     */
+    muzzleOffsetFactor: number;
   };
   mine: {
     /** Durée de la mèche avant détonation, en secondes. */
@@ -106,6 +119,33 @@ export interface Tuning {
     cooldownSeconds: number;
     /** Rayon de collision d'une mine, en tuiles. Sert aux impacts d'obus. */
     radiusTiles: number;
+  };
+  /**
+   * Réglages communs à tous les tanks de l'IA.
+   *
+   * Ce qui distingue une couleur d'une autre vit dans `systems/ai/profiles.ts`.
+   * Ce qui suit s'applique à toutes, et se ressent en jeu — d'où sa présence
+   * ici plutôt qu'en constante enfouie dans `brain.ts`.
+   */
+  ai: {
+    /**
+     * Écart de visée en deçà duquel un tank se juge aligné et tire, en radians.
+     *
+     * Trop serré, la tourelle oscille sans jamais déclencher ; trop large, les
+     * obus partent manifestement à côté.
+     */
+    aimToleranceRadians: number;
+    /** Durée minimale d'une direction de patrouille, en secondes. */
+    roamMinSeconds: number;
+    /** Durée maximale d'une direction de patrouille, en secondes. */
+    roamMaxSeconds: number;
+    /**
+     * Horizon d'anticipation pour l'esquive, en secondes.
+     *
+     * Un obus qui atteindra le tank au-delà de ce délai est ignoré : réagir
+     * trop tôt donnerait des tanks qui fuient des projectiles encore lointains.
+     */
+    evasionHorizonSeconds: number;
   };
 }
 
@@ -136,6 +176,7 @@ export const TUNING: Tuning = {
     normalSpeedTilesPerSecond: speedFromCrossing(SHELL_CROSSING_SECONDS),
     fastSpeedTilesPerSecond: speedFromCrossing(SHELL_CROSSING_SECONDS) * 2,
     cooldownSeconds: 0.2,
+    muzzleOffsetFactor: 0.55,
   },
   // ⚠ SECTION NON MESURÉE — en attente de relevé sur le jeu original.
   //
@@ -157,5 +198,11 @@ export const TUNING: Tuning = {
     blastDurationSeconds: 0.35,
     cooldownSeconds: 0.5,
     radiusTiles: 0.35,
+  },
+  ai: {
+    aimToleranceRadians: 0.08,
+    roamMinSeconds: 0.5,
+    roamMaxSeconds: 2,
+    evasionHorizonSeconds: 1,
   },
 };

--- a/tests/tuning-guard.test.ts
+++ b/tests/tuning-guard.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { TUNING } from '../src/core/tuning.js';
+import { TANK_PROFILES } from '../src/core/systems/ai/profiles.js';
+
+/**
+ * Garde contre le retour des valeurs magiques.
+ *
+ * L'ancienne version avait ses constantes de gameplay éparpillées dans cinq
+ * fichiers, parfois répétées avec des valeurs légèrement différentes. C'est ce
+ * qui rendait toute calibration impossible : ajuster une vitesse demandait de
+ * savoir où chercher, et de n'en oublier aucune.
+ *
+ * ─── La règle ────────────────────────────────────────────────────────────────
+ *
+ * Dans `src/core/`, un littéral numérique doit être **soit structurel, soit
+ * nommé**. Autrement dit : aucun nombre ne peut apparaître au milieu d'une
+ * expression sans qu'on puisse dire, en lisant son nom, ce qu'il représente.
+ *
+ * La frontière, explicite, entre ce qui va dans `tuning.ts` / `profiles.ts` et
+ * ce qui peut rester une constante nommée dans un système :
+ *
+ *   · **réglable** — ce qu'un joueur *ressent* : vitesses, durées, rayons,
+ *     quotas, portées, cônes d'erreur. Ça vit dans les tables, et le panneau
+ *     de calibration l'expose ;
+ *   · **structurel** — les paramètres de la méthode numérique : tolérances,
+ *     plafonds d'itération, nombre d'échantillons, budgets de calcul. Changer
+ *     ces valeurs ne change pas le jeu, seulement la précision ou le coût.
+ *     Ça reste au plus près du code concerné, sous un nom explicite.
+ *
+ * Ce test ne peut pas trancher cette frontière à ma place — aucun outil ne
+ * peut. Ce qu'il garantit, c'est qu'aucun nombre ne se glisse **anonymement**
+ * dans la logique : tout ce qui n'est pas trivial porte un nom, donc se voit,
+ * se cherche et se discute.
+ */
+
+/* ── Ce qui est toléré en clair ─────────────────────────────────────────── */
+
+/**
+ * Littéraux autorisés partout, parce qu'ils n'expriment jamais un réglage.
+ *
+ * `0` et `1` sont les neutres de l'addition et de la multiplication, `2` sert
+ * aux moitiés et aux doublements, `0.5` au centre d'une tuile. Aucun de ces
+ * nombres ne se règle : les remplacer par une constante nommée n'apprendrait
+ * rien à personne.
+ */
+const STRUCTURAL_LITERALS = new Set(['0', '1', '2', '0.5']);
+
+/** Fichiers qui ont le droit de contenir des valeurs de gameplay. */
+const TUNING_FILES = new Set([
+  'src/core/tuning.ts',
+  'src/core/systems/ai/profiles.ts',
+  // Formes de données : les valeurs de `TileKind` sont un encodage, pas un
+  // réglage — changer `Hole: 3` ne change pas le jeu, ça casse la
+  // sérialisation.
+  'src/core/state.ts',
+  // Arithmétique binaire du générateur pseudo-aléatoire : décalages et
+  // constantes de mélange. Aucune n'a de sens de gameplay, et les nommer une à
+  // une rendrait l'algorithme moins lisible, pas plus.
+  'src/core/rng.ts',
+]);
+
+/** Repère une ligne qui *nomme* sa valeur : `const NOM_EN_MAJUSCULES = …`. */
+const NAMED_CONSTANT = /^\s*(?:export\s+)?const\s+[A-Z][A-Z0-9_]*\s*(?::[^=]+)?=/;
+
+/* ── Collecte ───────────────────────────────────────────────────────────── */
+
+function sourceFiles(root: string): string[] {
+  const found: string[] = [];
+
+  const walk = (directory: string): void => {
+    for (const entry of readdirSync(directory)) {
+      const path = join(directory, entry);
+      if (statSync(path).isDirectory()) walk(path);
+      else if (path.endsWith('.ts')) found.push(path);
+    }
+  };
+
+  walk(root);
+  return found.sort();
+}
+
+/**
+ * Retire commentaires et chaînes.
+ *
+ * Sans ça, la garde se déclencherait sur les nombres cités dans la prose des
+ * commentaires — et ce fichier-ci en contient beaucoup.
+ */
+function stripNoise(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+    .replace(/(["'`])(?:\\.|(?!\1).)*\1/g, "''");
+}
+
+interface Offence {
+  where: string;
+  literal: string;
+  line: string;
+}
+
+function findOffences(): Offence[] {
+  const offences: Offence[] = [];
+
+  for (const file of sourceFiles('src/core')) {
+    if (TUNING_FILES.has(file)) continue;
+
+    stripNoise(readFileSync(file, 'utf8'))
+      .split('\n')
+      .forEach((line, index) => {
+        // Une ligne qui nomme sa constante est acceptable quelle que soit sa
+        // valeur : c'est exactement ce qu'on demande.
+        if (NAMED_CONSTANT.test(line)) return;
+
+        // Pas de `.` ni de mot juste avant : on écarte `state.a`, `x2`, et les
+        // parties décimales déjà capturées.
+        for (const match of line.matchAll(/(?<![\w.$])(0x[0-9a-fA-F_]+|\d+\.?\d*(?:e[-+]?\d+)?)/gi)) {
+          const literal = match[1]!;
+
+          if (STRUCTURAL_LITERALS.has(literal)) continue;
+          // Notation scientifique : une tolérance numérique, jamais un réglage.
+          if (/e[-+]?\d+$/i.test(literal)) continue;
+          // Hexadécimal : manipulation de bits.
+          if (literal.startsWith('0x')) continue;
+
+          offences.push({ where: `${file}:${index + 1}`, literal, line: line.trim() });
+        }
+      });
+  }
+
+  return offences;
+}
+
+/* ── Vérifications ──────────────────────────────────────────────────────── */
+
+describe('aucune valeur magique dans la logique', () => {
+  test('tout littéral non structurel de src/core porte un nom', () => {
+    const offences = findOffences();
+
+    const report = offences
+      .map((offence) => `${offence.where} — « ${offence.literal} » dans : ${offence.line}`)
+      .join('\n');
+
+    expect(report).toBe('');
+  });
+
+  test('la garde détecte bien une valeur magique introduite', () => {
+    // Auto-vérification : un test de garde qui ne peut pas échouer ne garde
+    // rien. On s'assure que le motif reconnaît le cas qu'il doit attraper.
+    const magic = stripNoise('const step = tank.speed * 3.7 * DT;');
+    expect(NAMED_CONSTANT.test(magic)).toBe(false);
+    expect(/(?<![\w.$])(\d+\.?\d*)/.exec(magic)?.[1]).toBe('3.7');
+  });
+
+  test('la garde accepte une constante nommée', () => {
+    expect(NAMED_CONSTANT.test('const MAX_BOUNCES_PER_TICK = 8;')).toBe(true);
+    expect(NAMED_CONSTANT.test('export const TICK_RATE = 60;')).toBe(true);
+    expect(NAMED_CONSTANT.test('const SEPARATION_EPSILON: number = 1e-6;')).toBe(true);
+    // Une variable ordinaire n'est pas une constante nommée.
+    expect(NAMED_CONSTANT.test('const speed = 3.7;')).toBe(false);
+  });
+
+  test('les commentaires ne déclenchent pas la garde', () => {
+    expect(stripNoise('// on vise 736 px en 4 s\nconst a = b;')).not.toContain('736');
+    expect(stripNoise('/* 2,7× trop lent */ const a = b;')).not.toContain('2,7');
+  });
+});
+
+describe('aucun réglage figé au chargement', () => {
+  /**
+   * `const X = TUNING.…` en portée de module capture la valeur **une fois**, à
+   * l'import. Le panneau de calibration a beau écrire dans la table ensuite, le
+   * code qui lit cette copie garde l'ancienne valeur — et rien ne le signale :
+   * le curseur bouge, l'affichage suit, le jeu non.
+   *
+   * C'est exactement ce qui était arrivé au couloir de menace de `threat.ts`.
+   * Une fonction, ou une lecture sur place, relit la table à chaque appel.
+   */
+  const FROZEN_READ = /^\s*(?:export\s+)?const\s+\w+\s*(?::[^=]+)?=\s*[^;]*\bTUNING\./;
+
+  test('aucun module ne recopie TUNING dans une constante', () => {
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles('src')) {
+      if (file === join('src', 'core', 'tuning.ts')) continue;
+
+      stripNoise(readFileSync(file, 'utf8'))
+        .split('\n')
+        .forEach((line, index) => {
+          // Seule la portée de module est concernée : à l'intérieur d'une
+          // fonction, la lecture se refait à chaque appel.
+          if (line.startsWith(' ') || line.startsWith('\t')) return;
+          if (FROZEN_READ.test(line)) offenders.push(`${file}:${index + 1} — ${line.trim()}`);
+        });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  test('la garde reconnaît la forme fautive', () => {
+    expect(FROZEN_READ.test('const CORRIDOR = TUNING.tank.sizeTiles;')).toBe(true);
+    expect(FROZEN_READ.test('export const HALF = TUNING.tank.sizeTiles / 2;')).toBe(true);
+    // Une lecture différée, elle, est correcte.
+    expect(FROZEN_READ.test('function corridor() { return TUNING.tank.sizeTiles; }')).toBe(false);
+  });
+});
+
+/* ── Complétude des tables ──────────────────────────────────────────────── */
+
+describe('les tables de réglage sont exploitables', () => {
+  /** Chemins `section.champ` de toutes les valeurs numériques d'un objet. */
+  function numericPaths(value: unknown, prefix = ''): string[] {
+    if (typeof value === 'number') return [prefix];
+    if (typeof value !== 'object' || value === null) return [];
+
+    return Object.entries(value).flatMap(([key, child]) =>
+      numericPaths(child, prefix ? `${prefix}.${key}` : key),
+    );
+  }
+
+  test('toutes les valeurs de TUNING sont finies', () => {
+    // Une valeur non finie ferait diverger la simulation sans rien signaler.
+    const table = TUNING as unknown as Record<string, unknown>;
+    for (const path of numericPaths(table)) {
+      const value = path
+        .split('.')
+        .reduce<unknown>((node, key) => (node as Record<string, unknown>)[key], table);
+
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  test('les profils couvrent les dix couleurs', () => {
+    expect(Object.keys(TANK_PROFILES).sort()).toEqual(
+      [
+        'ash',
+        'black',
+        'brown',
+        'green',
+        'pink',
+        'player',
+        'purple',
+        'teal',
+        'white',
+        'yellow',
+      ].sort(),
+    );
+  });
+
+  test('les tables sont modifiables en place', () => {
+    // Le panneau de calibration écrit directement dedans : un `Object.freeze`
+    // ou un `as const` de trop le rendrait inopérant, et le seul moment où on
+    // s'en apercevrait serait manette en main.
+    const before = TUNING.tank.speedTilesPerSecond;
+    TUNING.tank.speedTilesPerSecond = before + 1;
+    expect(TUNING.tank.speedTilesPerSecond).toBe(before + 1);
+    TUNING.tank.speedTilesPerSecond = before;
+
+    const rate = TANK_PROFILES.brown.turretRateRadiansPerSecond;
+    TANK_PROFILES.brown.turretRateRadiansPerSecond = rate + 1;
+    expect(TANK_PROFILES.brown.turretRateRadiansPerSecond).toBe(rate + 1);
+    TANK_PROFILES.brown.turretRateRadiansPerSecond = rate;
+  });
+});


### PR DESCRIPTION
Ferme #10.

C'est le lot qui ferme la boucle ouverte par l'exigence de fidélité absolue. Les constantes exactes du jeu Wii ne sont documentées nulle part : la seule méthode honnête est de partir des temps de traversée mesurés — les seuls faits observables — puis d'ajuster le reste **au ressenti, manette en main**. Sans outil, cette seconde étape voudrait dire éditer un fichier, recompiler, relancer une partie, et essayer de se souvenir de la sensation d'il y a trente secondes.

## Le panneau — touche `~`

Une quarantaine de curseurs sur `TUNING`, plus le profil d'une couleur à la fois (dix profils × quatorze réglages feraient cent quarante curseurs où l'on ne trouverait plus rien).

**Aucun rechargement.** Un test bout-en-bout ne se contente pas de vérifier que la table a changé : il pilote le tank, mesure la distance parcourue en 700 ms, déplace le curseur, remesure, et exige que le tank ait réellement ralenti.

Deux choix qui comptent :

- **Les vitesses se règlent en secondes de traversée d'arène**, pas en tuiles par seconde. C'est la grandeur qu'on sait chronométrer sur l'original, donc celle dans laquelle on compare. L'export JSON s'ouvre d'ailleurs sur un bloc `mesures` avant la table elle-même.
- **`Number.POSITIVE_INFINITY` est traité explicitement.** La tourelle et la portée du joueur valent l'infini ; un curseur ne sait pas le représenter, et le remplacer par une grande valeur finie changerait le comportement en douce — ces deux réglages sont donc simplement absents, avec une note. À l'export, `JSON.stringify` les transformerait silencieusement en `null` : ils sont écrits en toutes lettres.

Le panneau n'introduit **aucune** valeur nouvelle. Il expose `TUNING` et `TANK_PROFILES`, qui restent la seule source de vérité, et ne persiste rien.

## Calques de débogage

Boîtes de collision, trajectoires prévues, rayons de souffle.

Ils lisent le `World` réel et non un instantané interpolé — entorse assumée à la séparation modèle/vue, et documentée comme telle dans l'interface `Renderer`. Une boîte de collision décalée d'une fraction de pas par rapport à celle qui décide réellement des impacts ne prouverait rien.

Les trajectoires réutilisent `traceShellPath`, c'est-à-dire **exactement** la fonction dont l'IA se sert pour chercher ses angles. Le calque montre donc ce que les ennemis calculent, pas une seconde implémentation qui pourrait en diverger.

## Garde anti-valeurs magiques

Dans `src/core/`, un littéral numérique doit être **soit structurel, soit nommé**. La frontière est explicitée dans le test :

| | |
|---|---|
| **réglable** | ce qu'un joueur *ressent* : vitesses, durées, rayons, quotas, portées. Ça vit dans les tables, et le panneau l'expose. |
| **structurel** | les paramètres de la méthode numérique : tolérances, plafonds d'itération, budgets de calcul. Changer ces valeurs ne change pas le jeu, seulement la précision ou le coût. Ça reste sous un nom explicite, au plus près du code concerné. |

Aucun outil ne peut trancher cette frontière à ma place. Ce que la garde assure, c'est qu'aucun nombre ne se glisse **anonymement** dans la logique : tout ce qui n'est pas trivial porte un nom, donc se voit, se cherche et se discute.

Cinq valeurs migrent vers les tables — la sortie de canon (`0.55`), la tolérance de visée, les deux bornes de patrouille, l'horizon d'esquive. Une sixième, le plafond d'itérations du lancer de rayon, prend un nom.

## Un vrai défaut, trouvé par la garde

`threat.ts` faisait, en portée de module :

```ts
const THREAT_CORRIDOR_TILES = TUNING.tank.sizeTiles;
```

La valeur était **figée à l'import**. Le panneau aurait eu beau modifier la taille du châssis, le couloir de menace serait resté à sa valeur de départ : le curseur bouge, l'affichage suit, le jeu non — et rien ne l'aurait signalé.

Une seconde garde interdit désormais cette forme dans tout `src/`, avec son auto-vérification.

## Sur le critère « supprimer `src/constants.ts` »

`src/constants.ts` n'existe plus depuis #5. L'ancien fichier vit dans `legacy/`, conservé comme pièce de provenance — c'est de lui que viennent les temps de traversée, les profils des neuf couleurs et les effectifs des vingt missions. Tout l'arbre `legacy/` part en #14 ; `scripts/convert-legacy-levels.ts` en dépend encore.

## Vérification

340 tests unitaires, 28 bout-en-bout, typecheck propre. Panneau et calques vérifiés à l'écran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
