### PR TITLE
feat(netcode): co-op en ligne à serveur autoritaire, prédiction et réconciliation

### DIFF
--- a/e2e/coop.spec.ts
+++ b/e2e/coop.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test } from '@playwright/test';
+
+// La déclaration de `window.__tanks` vit dans src/client/debug-bridge.ts.
+import '../src/client/debug-bridge';
+
+type Page = import('@playwright/test').Page;
+
+/**
+ * Co-op en ligne, deux navigateurs dans la même salle.
+ *
+ * ─── Ce que ces tests exigent de l'environnement ────────────────────────────
+ *
+ * Un serveur de jeu doit tourner sur le port 3000 (`bun run serve`), et le
+ * client doit avoir été construit (`bun run build`) puisque c'est ce serveur qui
+ * sert les fichiers. `playwright.config.ts` s'en charge.
+ *
+ * ⚠ Chromium ralentit le `requestAnimationFrame` des onglets en arrière-plan.
+ * Avec deux pages ouvertes, celle qui n'a pas le dessus voit sa boucle de jeu
+ * tomber à quelques images par seconde et n'envoie plus d'intentions — ce qui
+ * ressemble trait pour trait à une panne réseau. Les drapeaux de lancement du
+ * projet désactivent ce ralentissement.
+ */
+
+const SERVER = 'http://localhost:3000';
+
+/** Ouvre un client dans une salle donnée et attend sa première réception. */
+async function openClient(page: Page, room: string, name: string): Promise<void> {
+  await page.goto(`${SERVER}/?enligne=1&salon=${room}&nom=${name}`);
+  await page.waitForFunction(() => (window.__tanks?.campaign?.enemiesLeft ?? 0) > 0, undefined, {
+    timeout: 15_000,
+  });
+}
+
+/** Positions des tanks de joueurs, telles que cette page les connaît. */
+async function playerTanks(page: Page) {
+  return page.evaluate(() =>
+    window
+      .__tanks!.world.tanks.filter((tank) => tank.playerId !== null)
+      .map((tank) => ({ id: tank.id, x: tank.x, y: tank.y }))
+      .sort((left, right) => left.id - right.id),
+  );
+}
+
+/** Salle distincte par test : les tests tournent en parallèle sur un serveur unique. */
+let counter = 0;
+const uniqueRoom = (): string => `e2e-${Date.now()}-${counter++}`;
+
+test('deux joueurs partagent la même partie', async ({ browser }) => {
+  const room = uniqueRoom();
+  const alpha = await browser.newPage();
+  const beta = await browser.newPage();
+
+  await openClient(alpha, room, 'Alpha');
+  await openClient(beta, room, 'Beta');
+
+  // Chacun voit l'autre dans son HUD.
+  await expect
+    .poll(() => alpha.evaluate(() => window.__tanks?.campaign?.teammates))
+    .toEqual(['Beta']);
+  await expect
+    .poll(() => beta.evaluate(() => window.__tanks?.campaign?.teammates))
+    .toEqual(['Alpha']);
+
+  // Deux tanks de joueurs, à des positions distinctes, dans les deux mondes.
+  const seenByAlpha = await playerTanks(alpha);
+  const seenByBeta = await playerTanks(beta);
+
+  expect(seenByAlpha).toHaveLength(2);
+  expect(seenByBeta).toHaveLength(2);
+  expect(seenByAlpha[0]!.id).not.toBe(seenByAlpha[1]!.id);
+
+  await alpha.close();
+  await beta.close();
+});
+
+test('le déplacement d\'un joueur est vu par l\'autre', async ({ browser }) => {
+  const room = uniqueRoom();
+  const alpha = await browser.newPage();
+  const beta = await browser.newPage();
+
+  await openClient(alpha, room, 'Alpha');
+  await openClient(beta, room, 'Beta');
+  await alpha.bringToFront();
+
+  const before = (await playerTanks(beta))[0]!;
+
+  // Vers le haut : les coéquipiers apparaissent côte à côte, et partir vers son
+  // voisin ne mesurerait qu'une collision entre tanks.
+  await alpha.keyboard.down('ArrowUp');
+  await alpha.waitForTimeout(1000);
+  await alpha.keyboard.up('ArrowUp');
+  await alpha.waitForTimeout(300);
+
+  const after = (await playerTanks(beta))[0]!;
+
+  // Une seconde à environ 3,3 tuiles par seconde. La marge est large : ce qu'on
+  // vérifie est que le mouvement traverse le serveur, pas sa vitesse — elle a
+  // ses propres tests.
+  expect(before.y - after.y).toBeGreaterThan(1.5);
+  expect(before.x).toBeCloseTo(after.x, 3);
+
+  await alpha.close();
+  await beta.close();
+});
+
+test('le tank local répond immédiatement, sans attendre le serveur', async ({ browser }) => {
+  const room = uniqueRoom();
+  const alpha = await browser.newPage();
+  await openClient(alpha, room, 'Alpha');
+  await alpha.bringToFront();
+
+  // Trois images après l'appui : sans prédiction locale, il ne se serait encore
+  // rien passé — l'aller-retour vers le serveur dure plus longtemps que ça.
+  const moved = await alpha.evaluate(async () => {
+    const own = (): number => {
+      const world = window.__tanks!.world;
+      return world.tanks.find((tank) => tank.playerId !== null)?.y ?? 0;
+    };
+
+    const before = own();
+    window.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowUp' }));
+
+    for (let frame = 0; frame < 3; frame++) {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    }
+
+    const after = own();
+    window.dispatchEvent(new KeyboardEvent('keyup', { code: 'ArrowUp' }));
+    return before - after;
+  });
+
+  expect(moved).toBeGreaterThan(0);
+
+  await alpha.close();
+});
+
+test('la déconnexion d\'un joueur ne perturbe ni l\'IA ni les autres', async ({ browser }) => {
+  const room = uniqueRoom();
+  const alpha = await browser.newPage();
+  const beta = await browser.newPage();
+
+  await openClient(alpha, room, 'Alpha');
+  await openClient(beta, room, 'Beta');
+  await beta.bringToFront();
+
+  const enemiesBefore = await beta.evaluate(() => window.__tanks!.campaign!.enemiesLeft);
+  const tickBefore = await beta.evaluate(() => window.__tanks!.world.tick);
+
+  await alpha.close();
+
+  // Le coéquipier reste annoncé, mais hors ligne : une coupure de quelques
+  // secondes est banale, et le retirer aussitôt de la liste laisserait croire
+  // qu'il a quitté la partie. Son siège lui est gardé — la disparition
+  // définitive après le délai de grâce a son propre test unitaire.
+  await expect
+    .poll(() => beta.evaluate(() => window.__tanks?.campaign?.teammates), { timeout: 10_000 })
+    .toEqual(['Alpha (hors ligne)']);
+
+  await beta.waitForTimeout(600);
+
+  // L'ancienne version désignait `player1` maître de l'IA : sa déconnexion
+  // arrêtait net les ennemis. Ici l'IA appartient au serveur.
+
+  expect(await beta.evaluate(() => window.__tanks!.world.tick)).toBeGreaterThan(tickBefore + 20);
+  expect(await beta.evaluate(() => window.__tanks!.campaign!.enemiesLeft)).toBe(enemiesBefore);
+
+  await beta.close();
+});
+
+test('deux salons différents ne se mélangent pas', async ({ browser }) => {
+  const alpha = await browser.newPage();
+  const beta = await browser.newPage();
+
+  await openClient(alpha, uniqueRoom(), 'Alpha');
+  await openClient(beta, uniqueRoom(), 'Beta');
+
+  expect(await alpha.evaluate(() => window.__tanks?.campaign?.teammates)).toEqual([]);
+  expect(await playerTanks(alpha)).toHaveLength(1);
+  expect(await playerTanks(beta)).toHaveLength(1);
+
+  await alpha.close();
+  await beta.close();
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "serve": "bun run src/server/main.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test ./tests",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "coop": "bun run build && bun run serve"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,12 @@ import { defineConfig, devices } from '@playwright/test';
  * Le jeu se dessine intégralement dans un canevas : il n'y a pas de DOM à
  * interroger. Les tests bout-en-bout travaillent donc par capture d'écran et
  * par inspection de l'état exposé sur `window` en mode debug.
+ *
+ * Deux serveurs sont démarrés :
+ *
+ *   - **Vite**, sur 5173, pour le solo et le terrain d'essai ;
+ *   - **le serveur de jeu**, sur 3000, pour le co-op (#13). Il sert lui-même
+ *     `dist/`, d'où la construction préalable.
  */
 export default defineConfig({
   testDir: './e2e',
@@ -16,14 +22,39 @@ export default defineConfig({
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+
+    launchOptions: {
+      /**
+       * Chromium ralentit `requestAnimationFrame` dans les onglets en
+       * arrière-plan. Les tests de co-op ouvrent deux pages : sans ces
+       * drapeaux, celle qui n'a pas le dessus tombe à quelques images par
+       * seconde et cesse d'émettre des intentions — ce qui ressemble trait pour
+       * trait à une panne réseau, et fait échouer les tests pour une raison qui
+       * n'a rien à voir avec le jeu.
+       */
+      args: [
+        '--disable-background-timer-throttling',
+        '--disable-backgrounding-occluded-windows',
+        '--disable-renderer-backgrounding',
+      ],
+    },
   },
 
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 
-  webServer: {
-    command: 'bun run dev',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env['CI'],
-    timeout: 30_000,
-  },
+  webServer: [
+    {
+      command: 'bun run dev',
+      url: 'http://localhost:5173',
+      reuseExistingServer: !process.env['CI'],
+      timeout: 30_000,
+    },
+    {
+      // Le serveur de jeu sert `dist/` : il faut donc construire avant.
+      command: 'bun run build && bun run serve',
+      url: 'http://localhost:3000',
+      reuseExistingServer: !process.env['CI'],
+      timeout: 60_000,
+    },
+  ],
 });

--- a/src/client/debug-bridge.ts
+++ b/src/client/debug-bridge.ts
@@ -13,7 +13,7 @@
 
 import type { World } from '@core/state';
 import type { Tuning } from '@core/tuning';
-import type { CampaignView } from './local/LocalCampaign';
+import type { CampaignView } from './session';
 
 /** Cadences mesurées, pour vérifier que la simulation reste indépendante de l'écran. */
 export interface RateProbe {

--- a/src/client/local/LocalCampaign.ts
+++ b/src/client/local/LocalCampaign.ts
@@ -1,165 +1,69 @@
 /**
- * Campagne solo : enchaîne les missions, gère la réserve de tanks.
+ * Campagne solo.
  *
- * Répartition des rôles, volontairement stricte :
+ * Enveloppe mince autour de {@link CampaignRunner}, qui vit dans `shared/` et
+ * que le serveur (#13) utilise à l'identique. Ce qui reste ici est ce qui ne
+ * concerne que le client : les instantanés de rendu et l'interpolation.
  *
- *   - `core/systems/mission.ts` **juge** l'issue d'un monde (pure lecture) ;
- *   - `shared/campaign.ts` **décide** de la suite (réducteur pur) ;
- *   - cette classe **orchestre** : elle tient le monde courant, compte le temps
- *     mort entre deux missions, et charge la suivante.
- *
- * Rien de ce qui est décidé ici n'est propre au solo. Quand le serveur arrivera
- * (#13), il tiendra exactement le même rôle d'orchestrateur avec les deux mêmes
- * modules en dessous — seule la provenance des intentions changera.
+ * Autrement dit, le mode solo n'est toujours pas un chemin de code parallèle.
+ * Il enchaîne les missions avec exactement le même code que le co-op, et
+ * appelle le même `tick()`.
  */
 
 import type { InputCommand, Tank, World } from '@core/state';
-import { enemiesRemaining, missionOutcome } from '@core/systems/mission';
-import type { MissionOutcome } from '@core/systems/mission';
-import { secondsToTicks } from '@core/tick';
-import { TUNING } from '@core/tuning';
-import { CAMPAIGN_LENGTH, advanceCampaign, startCampaign } from '@shared/campaign';
-import type { CampaignState, CampaignStatus } from '@shared/campaign';
-import { loadMission } from '@shared/missions/load';
-import { missionByNumber } from '@shared/missions/missions';
+import { CampaignRunner } from '@shared/CampaignRunner';
+import { captureSnapshot, interpolateSnapshots } from '../render/snapshots';
 import type { RenderSnapshot } from '../render/snapshots';
-import type { Session } from '../session';
-import { LocalGame } from './LocalGame';
+import { buildCampaignView } from '../session';
+import type { CampaignView, Session } from '../session';
 
-/** Identifiant du joueur local. Le multijoueur en attribuera un par connexion. */
+/** Identifiant du joueur local. Le co-op en attribue un par connexion. */
 const LOCAL_PLAYER = 'local';
 
-/**
- * Temps mort après une mission réussie, en secondes.
- *
- * La simulation continue d'avancer pendant ce délai : l'explosion du dernier
- * ennemi doit se jouer entièrement, sinon la mission se coupe sur une image
- * figée et le coup gagnant n'est jamais vu.
- */
-const CLEARED_PAUSE_SECONDS = 1.6;
-
-/** Temps mort après un échec. Un peu plus long : il y a une mauvaise nouvelle à lire. */
-const FAILED_PAUSE_SECONDS = 2.2;
-
-/** Tout ce que le HUD et les tests ont besoin de savoir. Recalculé à chaque pas. */
-export interface CampaignView {
-  mission: number;
-  missionName: string;
-  totalMissions: number;
-  /** Tanks en réserve. */
-  spares: number;
-  /** Tentative en cours sur cette mission, à partir de 1. */
-  attempt: number;
-  status: CampaignStatus;
-  /** Issue de la mission en cours. */
-  outcome: MissionOutcome;
-  enemiesLeft: number;
-
-  activeShells: number;
-  maxShells: number;
-  activeMines: number;
-  maxMines: number;
-  playerAlive: boolean;
-}
-
 export class LocalCampaign implements Session {
-  #state: CampaignState;
-  #game: LocalGame;
+  readonly #runner: CampaignRunner;
 
-  /**
-   * Pas restants avant de charger la mission suivante.
-   *
-   * Zéro tant que la mission est en cours. Passer par un décompte plutôt que
-   * par une date rend la transition indépendante de la fréquence d'affichage,
-   * comme le reste de la simulation.
-   */
-  #pauseTicks = 0;
+  /** Les deux derniers états, pour interpoler le rendu entre deux pas. */
+  #previous: RenderSnapshot;
+  #current: RenderSnapshot;
 
   constructor(startingMission = 1) {
-    this.#state = startCampaign(startingMission);
-    this.#game = this.#openMission();
+    this.#runner = new CampaignRunner({ playerIds: [LOCAL_PLAYER], startingMission });
+    this.#current = captureSnapshot(this.#runner.world);
+    this.#previous = this.#current;
   }
 
   get world(): World {
-    return this.#game.world;
+    return this.#runner.world;
   }
 
   get playerTank(): Tank | undefined {
-    return this.#game.playerTank;
+    return this.#runner.tankOf(LOCAL_PLAYER);
   }
 
-  /** Reprend la campagne depuis la première mission. */
   restart(): void {
-    this.#state = startCampaign();
-    this.#pauseTicks = 0;
-    this.#game = this.#openMission();
+    this.#runner.restart();
+    this.#current = captureSnapshot(this.#runner.world);
+    this.#previous = this.#current;
   }
 
-  /** Avance d'un pas de simulation, et enchaîne les missions le moment venu. */
   update(input: InputCommand): void {
-    this.#game.update(input);
+    this.#previous = this.#current;
 
-    // Campagne terminée : le monde continue de tourner en toile de fond, mais
-    // plus aucune transition n'est déclenchée.
-    if (this.#state.status !== 'playing') return;
+    const tankId = this.#runner.tankIdOf(LOCAL_PLAYER);
+    this.#runner.step(tankId === undefined ? [] : [[tankId, input]]);
 
-    if (this.#pauseTicks > 0) {
-      this.#pauseTicks--;
-      if (this.#pauseTicks === 0) this.#resolve();
-      return;
-    }
-
-    const outcome = missionOutcome(this.#game.world);
-    if (outcome === 'playing') return;
-
-    this.#pauseTicks = secondsToTicks(
-      outcome === 'cleared' ? CLEARED_PAUSE_SECONDS : FAILED_PAUSE_SECONDS,
-    );
+    this.#current = captureSnapshot(this.#runner.world);
   }
 
   view(alpha: number): RenderSnapshot {
-    return this.#game.view(alpha);
+    // Un changement de mission remplace le monde : interpoler entre deux
+    // missions ferait glisser les tanks de l'ancienne arène vers la nouvelle.
+    if (this.#current.tick < this.#previous.tick) return this.#current;
+    return interpolateSnapshots(this.#previous, this.#current, alpha);
   }
 
-  /** Instantané lisible de la campagne. Sans effet sur la simulation. */
   status(): CampaignView {
-    const tank = this.#game.playerTank;
-    const mission = missionByNumber(this.#state.mission);
-
-    return {
-      mission: this.#state.mission,
-      missionName: mission?.name ?? '—',
-      totalMissions: CAMPAIGN_LENGTH,
-      spares: this.#state.spares,
-      attempt: this.#state.attempt,
-      status: this.#state.status,
-      // Pendant le temps mort la mission est jugée, mais pas encore résolue :
-      // c'est ce qui permet au HUD d'afficher le bandeau au bon moment.
-      outcome: missionOutcome(this.#game.world),
-      enemiesLeft: enemiesRemaining(this.#game.world),
-
-      activeShells: tank?.activeShells ?? 0,
-      maxShells: TUNING.tank.maxActiveShells,
-      activeMines: tank?.activeMines ?? 0,
-      maxMines: TUNING.tank.maxActiveMines,
-      playerAlive: tank?.alive ?? false,
-    };
-  }
-
-  /* ── Enchaînement ────────────────────────────────────────────────────── */
-
-  /** Applique l'issue de la mission écoulée et ouvre la suivante s'il y en a une. */
-  #resolve(): void {
-    this.#state = advanceCampaign(this.#state, missionOutcome(this.#game.world));
-    if (this.#state.status === 'playing') this.#game = this.#openMission();
-  }
-
-  /** Charge la mission courante dans un monde neuf. */
-  #openMission(): LocalGame {
-    const mission = missionByNumber(this.#state.mission);
-    if (!mission) throw new Error(`Mission ${this.#state.mission} inexistante`);
-
-    const { world, playerTankIds } = loadMission(mission, { playerIds: [LOCAL_PLAYER] });
-    return new LocalGame(world, playerTankIds[0]!);
+    return buildCampaignView(this.#runner.campaign, this.#runner.world, this.playerTank);
   }
 }

--- a/src/client/local/sandbox.ts
+++ b/src/client/local/sandbox.ts
@@ -27,7 +27,7 @@ import { createTank, createWorld } from '@core/world';
 import { parseMission } from '@shared/missions/parse';
 import type { RenderSnapshot } from '../render/snapshots';
 import type { Session } from '../session';
-import type { CampaignView } from './LocalCampaign';
+import type { CampaignView } from '../session';
 import { LocalGame } from './LocalGame';
 
 const SANDBOX = `

--- a/src/client/loop.ts
+++ b/src/client/loop.ts
@@ -1,74 +1,13 @@
 /**
- * Boucle à pas de temps fixe.
+ * Boucle de jeu du client.
  *
- * La simulation avance par pas de `DT` exactement, quelle que soit la fréquence
- * d'affichage. Le rendu, lui, s'exécute à la fréquence de l'écran et interpole
- * entre le dernier état simulé et le précédent grâce au résidu `alpha`.
- *
- * L'accumulateur est volontairement séparé du pilote `requestAnimationFrame` :
- * c'est la partie qui contient la logique délicate, et elle doit être testable
- * en headless. `FixedTimestep` ne touche donc à rien de spécifique au
- * navigateur.
+ * Seule `startGameLoop` connaît le navigateur ; tout le cadencement vit dans
+ * {@link FixedTimestep}, partagé avec le serveur (#13).
  */
 
-import { DT } from '@core/tick.js';
+import { FixedTimestep } from '@shared/timestep';
 
-/**
- * Nombre maximal de pas rattrapés en une passe.
- *
- * Sans ce plafond, un gel de l'onglet de dix secondes demanderait 600 pas d'un
- * coup ; le rattrapage prendrait plus de temps que le retard accumulé, ce qui
- * creuserait encore l'écart — la « spirale de la mort ». Au-delà du plafond, on
- * abandonne le retard : mieux vaut un saut visible qu'un blocage définitif.
- */
-export const MAX_CATCHUP_TICKS = 5;
-
-/** Durée maximale prise en compte pour une frame, en secondes. */
-export const MAX_FRAME_SECONDS = MAX_CATCHUP_TICKS * DT;
-
-export class FixedTimestep {
-  /** Temps accumulé pas encore converti en pas de simulation, en secondes. */
-  #accumulator = 0;
-
-  /** Fraction de pas restante, dans [0, 1). Sert à interpoler le rendu. */
-  #alpha = 0;
-
-  /**
-   * Absorbe le temps réel écoulé et rend le nombre de pas de simulation à
-   * exécuter.
-   *
-   * @param elapsedSeconds temps écoulé depuis l'appel précédent
-   * @returns nombre de pas à exécuter, entre 0 et {@link MAX_CATCHUP_TICKS}
-   */
-  advance(elapsedSeconds: number): number {
-    // On borne l'entrée plutôt que le nombre de pas : le temps excédentaire ne
-    // doit pas rester dans l'accumulateur, sinon il ressortirait à la frame
-    // suivante et le rattrapage recommencerait indéfiniment.
-    const clamped = Math.min(Math.max(elapsedSeconds, 0), MAX_FRAME_SECONDS);
-
-    this.#accumulator += clamped;
-
-    let ticks = 0;
-    while (this.#accumulator >= DT) {
-      this.#accumulator -= DT;
-      ticks++;
-    }
-
-    this.#alpha = this.#accumulator / DT;
-    return ticks;
-  }
-
-  /** Résidu d'interpolation courant, dans [0, 1). */
-  get alpha(): number {
-    return this.#alpha;
-  }
-
-  /** Remet l'accumulateur à zéro, par exemple au chargement d'une mission. */
-  reset(): void {
-    this.#accumulator = 0;
-    this.#alpha = 0;
-  }
-}
+export { FixedTimestep, MAX_CATCHUP_TICKS, MAX_FRAME_SECONDS } from '@shared/timestep';
 
 /** Ce qu'une boucle de jeu doit fournir. */
 export interface GameLoopHandlers {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -8,8 +8,10 @@
  *
  * ─── Modes ───────────────────────────────────────────────────────────────────
  *
- *   (aucun paramètre)  la campagne, à partir de la mission 1
- *   ?mission=N         la campagne, à partir de la mission N
+ *   (aucun paramètre)  la campagne solo, à partir de la mission 1
+ *   ?mission=N         la campagne solo, à partir de la mission N
+ *   ?enligne=1         le co-op, salon « principal »
+ *   ?enligne=1&salon=X un salon nommé
  *   ?bac=1             le terrain d'essai des tests bout-en-bout
  *   ?bac=1&calme=1     le même, sans ennemis
  *
@@ -25,6 +27,8 @@ import { InputSampler } from './input/sampler';
 import { LocalCampaign } from './local/LocalCampaign';
 import { createSandboxSession } from './local/sandbox';
 import { startGameLoop } from './loop';
+import { Connection, stablePlayerId } from './net/connection';
+import { NetworkSession } from './net/NetworkSession';
 import { BOARD_BOTTOM_BAND_PX, Canvas2DRenderer } from './render/canvas2d/Canvas2DRenderer';
 import type { Session } from './session';
 import { drawHud } from './ui/hud';
@@ -50,10 +54,60 @@ function requestedMission(params: URLSearchParams): number {
   return Math.min(Math.max(raw, 1), CAMPAIGN_LENGTH);
 }
 
+/** Port sur lequel Vite sert la page en développement. */
+const VITE_DEV_PORT = '5173';
+
+/** Port du serveur de jeu. */
+const GAME_SERVER_PORT = '3000';
+
+/**
+ * Adresse du serveur de jeu.
+ *
+ * Deux situations. En développement, Vite sert la page et le serveur de jeu
+ * tourne à côté : il faut donc changer de port. En production, le serveur de jeu
+ * sert lui-même les fichiers, et l'hôte courant est le bon.
+ *
+ * `?serveur=` court-circuite la déduction, pour pointer une autre machine.
+ */
+function serverUrl(params: URLSearchParams): string {
+  const explicit = params.get('serveur');
+  if (explicit) return explicit;
+
+  const scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const host =
+    window.location.port === VITE_DEV_PORT
+      ? `${window.location.hostname}:${GAME_SERVER_PORT}`
+      : window.location.host;
+
+  return `${scheme}//${host}/ws`;
+}
+
 function createSession(params: URLSearchParams): Session {
   if (params.has('bac')) {
     return createSandboxSession({ withEnemies: !params.has('calme') });
   }
+
+  if (params.has('enligne')) {
+    const room = params.get('salon') ?? 'principal';
+    const playerId = stablePlayerId();
+
+    // La session est construite avant la connexion : le transport lui est
+    // donné, et les messages lui arrivent ensuite. C'est ce qui permet de la
+    // tester avec un transport factice, sans WebSocket.
+    let network: NetworkSession;
+    const connection = new Connection({
+      url: serverUrl(params),
+      playerId,
+      room,
+      name: params.get('nom') ?? `Joueur ${playerId.slice(0, 4)}`,
+      onMessage: (message) => network.handle(message),
+      onClose: () => network.disconnected(),
+    });
+
+    network = new NetworkSession(connection);
+    return network;
+  }
+
   return new LocalCampaign(requestedMission(params));
 }
 
@@ -63,7 +117,14 @@ const renderer = new Canvas2DRenderer(canvas);
 const params = new URLSearchParams(window.location.search);
 const session = createSession(params);
 
-renderer.resize(session.world.grid);
+/**
+ * Dimensions pour lesquelles la surface de rendu est dimensionnée.
+ *
+ * Vérifiées à chaque frame plutôt qu'une fois au démarrage : en co-op, le
+ * terrain n'arrive qu'après la connexion, et le canevas serait resté à la
+ * taille du monde d'attente.
+ */
+let sizedFor = { width: 0, height: 0 };
 
 const sampler = new InputSampler(canvas, (clientX, clientY) =>
   renderer.pointerToWorld(clientX, clientY),
@@ -185,7 +246,13 @@ startGameLoop({
     rates.frames++;
     sampleRates(performance.now());
 
-    renderer.draw(session.world.grid, session.view(alpha));
+    const grid = session.world.grid;
+    if (grid.width !== sizedFor.width || grid.height !== sizedFor.height) {
+      sizedFor = { width: grid.width, height: grid.height };
+      renderer.resize(grid);
+    }
+
+    renderer.draw(grid, session.view(alpha));
     renderer.drawDebug(session.world, panel.debug);
 
     if (overlayCtx) {

--- a/src/client/net/NetworkSession.ts
+++ b/src/client/net/NetworkSession.ts
@@ -1,0 +1,288 @@
+/**
+ * Partie en ligne, vue du client.
+ *
+ * ─── Les deux régimes, et pourquoi ils cohabitent ───────────────────────────
+ *
+ * **Le tank local est prédit.** Son intention s'applique au pas même où elle est
+ * saisie, sans attendre le serveur — sinon le pilotage serait pâteux, et c'est
+ * la première chose qu'on remarque. Voir {@link Reconciler}.
+ *
+ * **Tout le reste est interpolé, avec ~100 ms de retard.** Les autres joueurs,
+ * les ennemis, les obus : leurs positions viennent des instantanés reçus, et on
+ * les affiche entre les deux derniers plutôt qu'au dernier connu. Ces entités
+ * ne sont **jamais** prédites : le client ignore les intentions des autres
+ * joueurs, une prédiction serait donc une invention, et chaque instantané la
+ * corrigerait par une téléportation.
+ *
+ * Le prix de ces 100 ms, c'est de voir les autres légèrement dans le passé. Le
+ * prix de la prédiction, ce serait de les voir sauter. Le second se remarque
+ * beaucoup plus.
+ *
+ * ─── Ce qui est dessiné vient donc de deux sources ──────────────────────────
+ *
+ *     tank local  ──► monde prédit          (immédiat)
+ *     le reste    ──► tampon d'instantanés  (retardé, lissé)
+ */
+
+import type { EntityId, InputCommand, Tank, TileKind, World } from '@core/state';
+import { TANK_PROFILES } from '@core/systems/ai/profiles';
+import { DT, TICK_RATE } from '@core/tick';
+import { TUNING } from '@core/tuning';
+import { createWorld } from '@core/world';
+import type { CampaignState } from '@shared/campaign';
+import { startCampaign } from '@shared/campaign';
+import { ARENA_HEIGHT_TILES, ARENA_WIDTH_TILES } from '@shared/missions/missions';
+import { INTERPOLATION_DELAY_SECONDS, withTiles } from '@shared/protocol';
+import type { LobbyPlayer, ServerMessage } from '@shared/protocol';
+import { captureSnapshot, interpolateSnapshots } from '../render/snapshots';
+import type { RenderSnapshot } from '../render/snapshots';
+import { buildCampaignView } from '../session';
+import type { CampaignView, Session } from '../session';
+import type { Transport } from './connection';
+import { Reconciler } from './reconciler';
+
+/** Retard d'affichage des entités distantes, en pas de simulation. */
+const INTERPOLATION_DELAY_TICKS = INTERPOLATION_DELAY_SECONDS * TICK_RATE;
+
+/**
+ * Instantanés conservés.
+ *
+ * Deux suffisent à interpoler ; on en garde davantage pour absorber une arrivée
+ * groupée sans perdre l'échantillon d'avant.
+ */
+const BUFFER_SIZE = 8;
+
+/**
+ * Écart au-delà duquel l'horloge d'affichage est recalée d'un coup, en pas.
+ *
+ * En deçà, on la corrige par petites touches — un saut d'horloge se voit comme
+ * une saccade générale. Au-delà, c'est une coupure ou un changement de salle :
+ * rattraper en douceur prendrait plusieurs secondes.
+ */
+const CLOCK_SNAP_TICKS = 30;
+
+interface BufferedSnapshot {
+  /** Horloge monotone de la salle. */
+  tick: number;
+  view: RenderSnapshot;
+}
+
+export class NetworkSession implements Session {
+  readonly #transport: Transport;
+  readonly #reconciler = new Reconciler();
+
+  /** Monde affiché tant qu'aucun instantané n'est arrivé. */
+  #placeholder: World;
+
+  /** Tuiles du terrain courant, reçues à part des instantanés. */
+  #tiles: TileKind[] | null = null;
+
+  #buffer: BufferedSnapshot[] = [];
+
+  /**
+   * Horloge d'affichage, en pas de la salle.
+   *
+   * Avance d'un pas par pas de simulation local, et se recale doucement pour
+   * rester {@link INTERPOLATION_DELAY_TICKS} derrière le dernier instantané reçu.
+   */
+  #renderClock = 0;
+  #clockStarted = false;
+
+  #campaign: CampaignState = startCampaign();
+  #players: LobbyPlayer[] = [];
+  #started = false;
+
+  /** Numéro de la prochaine intention émise. */
+  #seq = 0;
+
+  #playerId: string | null = null;
+  #connected = false;
+
+  constructor(transport: Transport) {
+    this.#transport = transport;
+    this.#placeholder = createWorld({
+      width: ARENA_WIDTH_TILES,
+      height: ARENA_HEIGHT_TILES,
+      seed: 0,
+    });
+  }
+
+  /* ── Contrat de session ───────────────────────────────────────────────── */
+
+  get world(): World {
+    return this.#reconciler.world ?? this.#placeholder;
+  }
+
+  get playerTank(): Tank | undefined {
+    const id = this.#reconciler.localTankId;
+    if (id === null) return undefined;
+    return this.#reconciler.world?.tanks.find((tank) => tank.id === id);
+  }
+
+  /** Y a-t-il un lien avec le serveur ? Le HUD l'affiche. */
+  get connected(): boolean {
+    return this.#connected;
+  }
+
+  update(input: InputCommand): void {
+    const seq = this.#seq++;
+
+    // L'intention part avant d'être appliquée : c'est la seule chose que le
+    // serveur acceptera d'un client, et plus tôt elle part, plus tôt elle
+    // est prise en compte.
+    this.#transport.send({ t: 'input', seq, input });
+    this.#reconciler.predict(seq, input);
+
+    if (this.#clockStarted) this.#renderClock += 1;
+  }
+
+  view(alpha: number): RenderSnapshot {
+    const remote = this.#interpolateRemote(alpha);
+    return this.#overrideLocalTank(remote);
+  }
+
+  status(): CampaignView {
+    const teammates = this.#players
+      .filter((player) => player.playerId !== this.#playerId)
+      .map((player) => (player.connected ? player.name : `${player.name} (hors ligne)`));
+
+    return buildCampaignView(this.#campaign, this.world, this.playerTank, teammates);
+  }
+
+  /** Demande le démarrage. Sans effet si la partie tourne déjà. */
+  restart(): void {
+    if (!this.#started) this.#transport.send({ t: 'start' });
+  }
+
+  /* ── Réception ────────────────────────────────────────────────────────── */
+
+  /** Traite un message du serveur. Point d'entrée unique du réseau. */
+  handle(message: ServerMessage): void {
+    switch (message.t) {
+      case 'welcome':
+        this.#playerId = message.playerId;
+        this.#connected = true;
+        // Le serveur fait autorité jusque sur les réglages : la prédiction doit
+        // tourner sur exactement la même table, sinon elle dérive à chaque pas
+        // et se fait corriger en permanence.
+        Object.assign(TUNING, message.tuning);
+        Object.assign(TANK_PROFILES, message.profiles);
+        break;
+
+      case 'lobby':
+        this.#players = message.players;
+        this.#started = message.started;
+        break;
+
+      case 'terrain':
+        this.#tiles = message.grid.tiles;
+        break;
+
+      case 'snapshot':
+        this.#applySnapshot(message);
+        break;
+
+      case 'bye':
+        this.#connected = false;
+        this.#reconciler.reset();
+        break;
+    }
+  }
+
+  /** Signale la perte du lien. Le dernier état reste affiché, figé. */
+  disconnected(): void {
+    this.#connected = false;
+  }
+
+  #applySnapshot(message: Extract<ServerMessage, { t: 'snapshot' }>): void {
+    // Sans terrain, impossible de reconstruire un monde jouable : la collision
+    // lirait un tableau de tuiles vide et rien ne bloquerait plus.
+    if (!this.#tiles) return;
+
+    const world = withTiles(message.world, this.#tiles);
+    const previous = this.#reconciler.world;
+
+    this.#reconciler.reconcile(world, message.ack, message.yourTankId);
+    this.#campaign = message.campaign;
+
+    // Changement de mission : le monde repart de zéro, et interpoler d'une
+    // arène à l'autre ferait glisser les tanks à travers l'écran.
+    if (previous && world.tick < previous.tick) this.#buffer = [];
+
+    this.#buffer.push({ tick: message.tick, view: captureSnapshot(world) });
+    if (this.#buffer.length > BUFFER_SIZE) this.#buffer.shift();
+
+    this.#steerClock(message.tick);
+  }
+
+  /**
+   * Recale l'horloge d'affichage sur le flux reçu.
+   *
+   * Le client et le serveur ne comptent pas exactement à la même vitesse : sans
+   * correction, l'horloge finirait par sortir du tampon, d'un côté ou de
+   * l'autre. La correction est d'un pas à la fois — un rattrapage brutal se
+   * verrait comme une saccade générale.
+   */
+  #steerClock(serverTick: number): void {
+    const target = serverTick - INTERPOLATION_DELAY_TICKS;
+
+    if (!this.#clockStarted || Math.abs(this.#renderClock - target) > CLOCK_SNAP_TICKS) {
+      this.#renderClock = target;
+      this.#clockStarted = true;
+      return;
+    }
+
+    if (this.#renderClock < target - 1) this.#renderClock += 1;
+    else if (this.#renderClock > target + 1) this.#renderClock -= 1;
+  }
+
+  /* ── Composition de l'image ───────────────────────────────────────────── */
+
+  /** Entités distantes, lues dans le passé et lissées entre deux instantanés. */
+  #interpolateRemote(alpha: number): RenderSnapshot {
+    const last = this.#buffer[this.#buffer.length - 1];
+    if (!last) return captureSnapshot(this.world);
+
+    const when = this.#renderClock + alpha;
+
+    // On cherche l'intervalle qui encadre l'instant visé.
+    for (let index = this.#buffer.length - 1; index > 0; index--) {
+      const after = this.#buffer[index]!;
+      const before = this.#buffer[index - 1]!;
+
+      if (when < before.tick || when > after.tick) continue;
+
+      const span = after.tick - before.tick;
+      const ratio = span > 0 ? (when - before.tick) / span : 1;
+      return interpolateSnapshots(before.view, after.view, ratio);
+    }
+
+    // Hors tampon : soit on est en avance sur le flux et il n'y a rien de plus
+    // récent à montrer, soit on a pris trop de retard. Le plus proche des deux
+    // bouts vaut mieux qu'une extrapolation inventée.
+    return when > last.tick ? last.view : this.#buffer[0]!.view;
+  }
+
+  /**
+   * Remplace le tank local par sa position prédite.
+   *
+   * C'est le point de jonction des deux régimes : le reste de l'image vient du
+   * passé, ce tank-ci vient du présent.
+   */
+  #overrideLocalTank(view: RenderSnapshot): RenderSnapshot {
+    const world = this.#reconciler.world;
+    const id: EntityId | null = this.#reconciler.localTankId;
+    if (!world || id === null) return view;
+
+    const predicted = captureSnapshot(world).tanks.find((tank) => tank.id === id);
+    if (!predicted) return view;
+
+    const tanks = view.tanks.filter((tank) => tank.id !== id);
+    tanks.push(predicted);
+
+    return { ...view, tanks };
+  }
+}
+
+/** Durée d'un pas, réexportée pour les tests de cadence réseau. */
+export { DT };

--- a/src/client/net/connection.ts
+++ b/src/client/net/connection.ts
@@ -1,0 +1,91 @@
+/**
+ * Connexion WebSocket typée.
+ *
+ * Le seul module du client qui connaisse `WebSocket`. Tout ce qui est au-dessus
+ * ne manipule que des messages du protocole — ce qui rend `NetworkSession`
+ * testable en lui donnant un transport factice.
+ */
+
+import { PROTOCOL_VERSION, decode, encode } from '@shared/protocol';
+import type { ClientMessage, ServerMessage } from '@shared/protocol';
+
+/** Ce que la session attend d'un transport. */
+export interface Transport {
+  send(message: ClientMessage): void;
+  close(): void;
+}
+
+export interface ConnectionOptions {
+  url: string;
+  /** Identifiant stable du joueur, pour qu'une reconnexion reprenne son siège. */
+  playerId: string;
+  name: string;
+  room: string;
+  onMessage(message: ServerMessage): void;
+  onOpen?(): void;
+  onClose?(): void;
+}
+
+/**
+ * Identifiant de joueur stable pour cet onglet.
+ *
+ * Conservé dans `sessionStorage` et non `localStorage` : deux onglets doivent
+ * pouvoir jouer côte à côte avec deux identités — c'est ce dont les tests
+ * bout-en-bout ont besoin, et ce qu'un joueur attend s'il ouvre une seconde
+ * fenêtre.
+ */
+export function stablePlayerId(): string {
+  const KEY = 'tanks.playerId';
+
+  const stored = sessionStorage.getItem(KEY);
+  if (stored) return stored;
+
+  const created = crypto.randomUUID();
+  sessionStorage.setItem(KEY, created);
+  return created;
+}
+
+export class Connection implements Transport {
+  readonly #socket: WebSocket;
+  readonly #options: ConnectionOptions;
+
+  constructor(options: ConnectionOptions) {
+    this.#options = options;
+
+    const url = new URL(options.url);
+    // L'identité voyage dans l'URL : le serveur doit la connaître avant même
+    // que le socket s'ouvre, pour rattacher une reconnexion à son siège.
+    url.searchParams.set('joueur', options.playerId);
+    url.searchParams.set('salon', options.room);
+
+    this.#socket = new WebSocket(url);
+
+    this.#socket.addEventListener('open', () => {
+      this.send({
+        t: 'join',
+        version: PROTOCOL_VERSION,
+        room: options.room,
+        name: options.name,
+      });
+      options.onOpen?.();
+    });
+
+    this.#socket.addEventListener('message', (event: MessageEvent) => {
+      const message = decode<ServerMessage>(event.data);
+      // Un message illisible est ignoré : il ne doit jamais interrompre la
+      // boucle de jeu.
+      if (message) options.onMessage(message);
+    });
+
+    this.#socket.addEventListener('close', () => options.onClose?.());
+  }
+
+  send(message: ClientMessage): void {
+    if (this.#socket.readyState !== WebSocket.OPEN) return;
+    this.#socket.send(encode(message));
+  }
+
+  close(): void {
+    this.#socket.close();
+  }
+}

--- a/src/client/net/reconciler.ts
+++ b/src/client/net/reconciler.ts
@@ -1,0 +1,114 @@
+/**
+ * Prédiction locale et réconciliation.
+ *
+ * ─── Le problème ────────────────────────────────────────────────────────────
+ *
+ * Le serveur fait autorité, mais il est à 30 ou 80 ms. Attendre sa réponse pour
+ * bouger rendrait le tank pâteux — c'est exactement la sensation qu'on cherche
+ * à éviter, et la fidélité du pilotage est la première chose qu'on remarque.
+ *
+ * ─── La réponse ─────────────────────────────────────────────────────────────
+ *
+ * Le client applique son intention **immédiatement** sur une copie locale du
+ * monde, et garde en mémoire tout ce que le serveur n'a pas encore confirmé.
+ * À chaque instantané reçu, il jette sa copie, adopte l'état serveur, puis
+ * **rejoue** les intentions non confirmées par-dessus. Le tank local retombe
+ * ainsi sur une position cohérente avec l'autorité, sans jamais avoir attendu.
+ *
+ * ─── Ce qui est prédit, et ce qui ne l'est pas ──────────────────────────────
+ *
+ * **Seul le tank local.** Le rejeu fait tourner `tick()` complet, IA comprise,
+ * mais les intentions des autres joueurs sont inconnues du client : leurs tanks
+ * finissent donc à des positions inventées. C'est sans conséquence, parce que
+ * rien de ce qui est prédit n'est affiché pour eux — ils sont interpolés depuis
+ * les instantanés reçus, avec un retard assumé (voir `NetworkSession`).
+ *
+ * Coût du rejeu : au plus une dizaine de pas, vingt fois par seconde. Le passage
+ * par `tick()` plutôt que par une intégration allégée est délibéré — une
+ * seconde implémentation du déplacement dériverait de la première, et c'est
+ * précisément le défaut qu'on a passé huit issues à éliminer.
+ */
+
+import type { EntityId, InputCommand, World } from '@core/state';
+import { tick } from '@core/tick';
+
+/** Une intention émise, en attente de confirmation. */
+interface PendingInput {
+  seq: number;
+  input: InputCommand;
+}
+
+/**
+ * Plafond d'intentions conservées.
+ *
+ * À 60 Hz, cinquante pas font plus de huit cents millisecondes : au-delà, c'est
+ * que le serveur ne répond plus, et rejouer une seconde entière de simulation
+ * à chaque instantané coûterait plus que ça ne corrigerait.
+ */
+const MAX_PENDING = 50;
+
+export class Reconciler {
+  #world: World | null = null;
+  #pending: PendingInput[] = [];
+  #localTankId: EntityId | null = null;
+
+  /** Monde prédit, ou `null` avant le premier instantané. */
+  get world(): World | null {
+    return this.#world;
+  }
+
+  /** Tank piloté, tel que désigné par le serveur. */
+  get localTankId(): EntityId | null {
+    return this.#localTankId;
+  }
+
+  /** Intentions encore non confirmées. Sert aux tests et au diagnostic. */
+  get pendingCount(): number {
+    return this.#pending.length;
+  }
+
+  /**
+   * Applique une intention locale sans attendre le serveur.
+   *
+   * L'intention est mémorisée même quand aucun monde n'est encore arrivé : elle
+   * sera rejouée sur le premier instantané, et le tank ne perdra pas les
+   * premières fractions de seconde de la partie.
+   */
+  predict(seq: number, input: InputCommand): void {
+    this.#pending.push({ seq, input });
+    if (this.#pending.length > MAX_PENDING) this.#pending.shift();
+
+    if (this.#world && this.#localTankId !== null) {
+      tick(this.#world, [[this.#localTankId, input]]);
+    }
+  }
+
+  /**
+   * Adopte l'état du serveur, puis rejoue ce qu'il n'a pas encore vu.
+   *
+   * @param authoritative monde reçu — pris tel quel, il vient d'être désérialisé
+   * @param ack dernier `seq` que le serveur a appliqué
+   * @param localTankId tank du joueur, `null` s'il n'en a pas encore
+   */
+  reconcile(authoritative: World, ack: number, localTankId: EntityId | null): void {
+    this.#localTankId = localTankId;
+    this.#world = authoritative;
+
+    // Tout ce que le serveur a déjà pris en compte est dans l'état reçu :
+    // le rejouer ferait avancer le tank deux fois.
+    this.#pending = this.#pending.filter((entry) => entry.seq > ack);
+
+    if (localTankId === null) return;
+
+    for (const { input } of this.#pending) {
+      tick(this.#world, [[localTankId, input]]);
+    }
+  }
+
+  /** Oublie tout. Appelé à la déconnexion, pour ne pas rejouer une partie morte. */
+  reset(): void {
+    this.#world = null;
+    this.#pending = [];
+    this.#localTankId = null;
+  }
+}

--- a/src/client/session.ts
+++ b/src/client/session.ts
@@ -1,11 +1,11 @@
 /**
  * Ce que le point d'entrée sait faire d'une partie, quelle qu'elle soit.
  *
- * Trois implémentations, présentes ou à venir :
+ * Trois implémentations :
  *
  *   - `LocalCampaign` — la campagne solo, vingt missions enchaînées ;
  *   - `createSandboxSession` — le terrain d'essai, une arène unique ;
- *   - la session réseau de #13, qui prédira le tank local et interpolera les
+ *   - `NetworkSession` — le co-op, qui prédit le tank local et interpole les
  *     autres.
  *
  * L'intérêt de cette interface n'est pas d'abstraire pour abstraire : c'est que
@@ -14,8 +14,80 @@
  */
 
 import type { InputCommand, Tank, World } from '@core/state';
-import type { CampaignView } from './local/LocalCampaign';
+import { enemiesRemaining, missionOutcome } from '@core/systems/mission';
+import type { MissionOutcome } from '@core/systems/mission';
+import { TUNING } from '@core/tuning';
+import { CAMPAIGN_LENGTH } from '@shared/campaign';
+import type { CampaignState, CampaignStatus } from '@shared/campaign';
+import { missionByNumber } from '@shared/missions/missions';
 import type { RenderSnapshot } from './render/snapshots';
+
+/**
+ * Tout ce que le HUD a besoin de savoir.
+ *
+ * Défini ici parce que c'est la valeur de retour de `Session.status()` : c'est
+ * le contrat, pas un détail de l'une des implémentations.
+ */
+export interface CampaignView {
+  mission: number;
+  missionName: string;
+  totalMissions: number;
+  /** Tanks en réserve. */
+  spares: number;
+  /** Tentative en cours sur cette mission, à partir de 1. */
+  attempt: number;
+  status: CampaignStatus;
+  /** Issue de la mission en cours. */
+  outcome: MissionOutcome;
+  enemiesLeft: number;
+
+  activeShells: number;
+  maxShells: number;
+  activeMines: number;
+  maxMines: number;
+  playerAlive: boolean;
+
+  /** Coéquipiers connectés, en co-op. Vide en solo. */
+  teammates: string[];
+}
+
+/**
+ * Compose la vue affichable.
+ *
+ * Partagé par la campagne solo et le co-op : l'état de campagne et le monde
+ * viennent de deux sources différentes — l'une locale, l'autre du serveur — mais
+ * ce qu'on en tire pour le HUD est identique, et le rester est justement ce
+ * qu'on veut garantir.
+ */
+export function buildCampaignView(
+  state: CampaignState,
+  world: World,
+  tank: Tank | undefined,
+  teammates: string[] = [],
+): CampaignView {
+  const mission = missionByNumber(state.mission);
+
+  return {
+    mission: state.mission,
+    missionName: mission?.name ?? '—',
+    totalMissions: CAMPAIGN_LENGTH,
+    spares: state.spares,
+    attempt: state.attempt,
+    status: state.status,
+    // Pendant le temps mort la mission est jugée, mais pas encore résolue :
+    // c'est ce qui permet au HUD d'afficher le bandeau au bon moment.
+    outcome: missionOutcome(world),
+    enemiesLeft: enemiesRemaining(world),
+
+    activeShells: tank?.activeShells ?? 0,
+    maxShells: TUNING.tank.maxActiveShells,
+    activeMines: tank?.activeMines ?? 0,
+    maxMines: TUNING.tank.maxActiveMines,
+    playerAlive: tank?.alive ?? false,
+
+    teammates,
+  };
+}
 
 export interface Session {
   /** Monde en cours. Change d'identité à chaque nouvelle mission. */

--- a/src/client/ui/hud.ts
+++ b/src/client/ui/hud.ts
@@ -12,7 +12,7 @@
  */
 
 import { BOARD_TOP_BAND_PX } from '../render/canvas2d/Canvas2DRenderer';
-import type { CampaignView } from '../local/LocalCampaign';
+import type { CampaignView } from '../session';
 import { TANK_COLORS } from '../render/palette';
 
 const HUD = {
@@ -113,7 +113,11 @@ export function drawHud(ctx: CanvasRenderingContext2D, view: CampaignView): void
   ctx.fillStyle = HUD.bandBackground;
   ctx.fillRect(0, 0, width, BAND_HEIGHT);
 
-  const middle = BAND_HEIGHT / 2;
+  // En co-op, deux lignes tiennent dans la bande : la ligne principale remonte
+  // pour laisser la place aux coéquipiers en dessous. Déborder sur le plateau
+  // masquerait le mur d'enceinte, ce qu'on vient justement de corriger.
+  const coop = view.teammates.length > 0;
+  const middle = coop ? 13 : BAND_HEIGHT / 2;
 
   ctx.fillStyle = HUD.text;
   ctx.font = 'bold 14px ui-monospace, monospace';
@@ -152,6 +156,13 @@ export function drawHud(ctx: CanvasRenderingContext2D, view: CampaignView): void
     width - 14,
     middle,
   );
+
+  if (coop) {
+    ctx.fillStyle = HUD.textDim;
+    ctx.font = '11px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = 'left';
+    ctx.fillText(`avec ${view.teammates.join(', ')}`, 14, BAND_HEIGHT - 11);
+  }
 
   /* ── Bandeau d'issue ───────────────────────────────────────────────── */
 

--- a/src/server/Room.ts
+++ b/src/server/Room.ts
@@ -1,0 +1,330 @@
+/**
+ * Une partie en ligne : un monde, N joueurs, et l'IA.
+ *
+ * ─── Ce qui change par rapport à l'ancienne version ─────────────────────────
+ *
+ * L'ancien serveur relayait du JSON sans jamais le lire, et désignait
+ * arbitrairement `player1` comme maître de l'IA — qui diffusait des paquets
+ * `enemyMove` que les autres appliquaient aveuglément. Trois conséquences : les
+ * états divergeaient à la première perte de paquet, la position d'un joueur
+ * était ce qu'il déclarait, et la déconnexion de `player1` arrêtait l'IA.
+ *
+ * Ici, **la salle est la seule chose qui existe**. Elle détient le monde, elle
+ * exécute toute l'IA, et elle n'accepte des clients que des intentions. Un
+ * joueur qui part ne retire que son tank.
+ *
+ * Cette classe ne connaît ni WebSocket ni transport : elle reçoit des messages
+ * décodés et rend des messages à envoyer. C'est ce qui la rend testable sans
+ * réseau, et c'est comme ça que le test de convergence l'exerce.
+ */
+
+import type { EntityId, InputCommand } from '@core/state';
+import { NEUTRAL_INPUT } from '@core/state';
+import { TANK_PROFILES } from '@core/systems/ai/profiles';
+import { TICK_RATE, secondsToTicks } from '@core/tick';
+import { TUNING } from '@core/tuning';
+import { CampaignRunner } from '@shared/CampaignRunner';
+import { SNAPSHOT_RATE, stripTiles } from '@shared/protocol';
+import type {
+  InputMessage,
+  LobbyPlayer,
+  ServerMessage,
+  SnapshotMessage,
+  TerrainMessage,
+} from '@shared/protocol';
+
+/**
+ * Profondeur maximale du tampon anti-gigue, en pas.
+ *
+ * Les intentions n'arrivent pas à intervalle régulier : le réseau les groupe et
+ * les espace. Sans tampon, une rafale de trois messages en ferait consommer un
+ * seul et jetterait les deux autres. Au-delà de ce plafond — environ un tiers
+ * de seconde d'avance — c'est que le client tourne trop vite ou qu'une rafale
+ * est arrivée d'un bloc : on rattrape en consommant plusieurs intentions par
+ * pas plutôt que de laisser le retard s'installer.
+ */
+const MAX_BUFFERED_INPUTS = 20;
+
+/** Profondeur visée : de quoi absorber la gigue sans ajouter de latence perceptible. */
+const TARGET_BUFFER_DEPTH = 2;
+
+/**
+ * Délai avant qu'un joueur déconnecté perde son tank, en secondes.
+ *
+ * Une coupure de quelques secondes est banale. Retirer le tank immédiatement
+ * punirait un incident réseau ; le laisser indéfiniment laisserait une épave
+ * immobile encaisser les tirs à la place de tout le monde.
+ */
+const DISCONNECT_GRACE_SECONDS = 10;
+
+/** Un joueur, du point de vue de la salle. */
+interface Player {
+  playerId: string;
+  name: string;
+  connected: boolean;
+  /** Intentions reçues et pas encore appliquées, dans l'ordre d'arrivée. */
+  pending: InputMessage[];
+  /** Dernière intention appliquée, rejouée si le tampon se vide. */
+  lastApplied: InputCommand;
+  /** `seq` de la dernière intention appliquée, renvoyé au client. */
+  ack: number;
+  /** Pas de simulation de la déconnexion, ou `null` si le joueur est là. */
+  disconnectedAtTick: number | null;
+}
+
+/** Message destiné à un joueur en particulier, ou à tout le salon. */
+export interface Outgoing {
+  /** Destinataire, ou `null` pour une diffusion. */
+  to: string | null;
+  message: ServerMessage;
+}
+
+export class Room {
+  readonly name: string;
+
+  readonly #players = new Map<string, Player>();
+  #runner: CampaignRunner | null = null;
+
+  #started = false;
+
+  /** Pas écoulés depuis la création. Sert d'horloge à la salle. */
+  #tick = 0;
+
+  /** Version de terrain déjà envoyée à chaque joueur, pour ne la diffuser qu'au changement. */
+  readonly #terrainVersionSent = new Map<string, number>();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  get started(): boolean {
+    return this.#started;
+  }
+
+  get tick(): number {
+    return this.#tick;
+  }
+
+  /** Monde courant, ou `null` tant que la partie n'a pas démarré. */
+  get world(): CampaignRunner['world'] | null {
+    return this.#runner?.world ?? null;
+  }
+
+  get isEmpty(): boolean {
+    return this.#players.size === 0;
+  }
+
+  /* ── Cycle de vie des joueurs ─────────────────────────────────────────── */
+
+  /**
+   * Installe ou réinstalle un joueur.
+   *
+   * Un identifiant déjà connu **reprend son siège** : c'est ce qui rend une
+   * reconnexion transparente après une coupure passagère.
+   */
+  join(playerId: string, name: string): Outgoing[] {
+    const existing = this.#players.get(playerId);
+
+    if (existing) {
+      existing.connected = true;
+      existing.disconnectedAtTick = null;
+      existing.name = name;
+    } else {
+      this.#players.set(playerId, {
+        playerId,
+        name,
+        connected: true,
+        pending: [],
+        lastApplied: NEUTRAL_INPUT,
+        ack: -1,
+        disconnectedAtTick: null,
+      });
+      // Arrivée libre : un nouveau venu reçoit un tank tout de suite plutôt que
+      // d'attendre la mission suivante.
+      this.#runner?.addPlayer(playerId);
+    }
+
+    // Le terrain devra être renvoyé : le client n'en a aucun.
+    this.#terrainVersionSent.delete(playerId);
+
+    const messages: Outgoing[] = [
+      {
+        to: playerId,
+        message: {
+          t: 'welcome',
+          playerId,
+          room: this.name,
+          tickRate: TICK_RATE,
+          snapshotRate: SNAPSHOT_RATE,
+          tuning: TUNING,
+          profiles: TANK_PROFILES,
+        },
+      },
+    ];
+
+    messages.push(this.#lobbyMessage());
+    return messages;
+  }
+
+  /** Signale une coupure. Le tank reste quelques secondes avant d'être retiré. */
+  disconnect(playerId: string): Outgoing[] {
+    const player = this.#players.get(playerId);
+    if (!player) return [];
+
+    player.connected = false;
+    player.disconnectedAtTick = this.#tick;
+    // Sinon le tank continuerait sur sa lancée, touche enfoncée, sans personne
+    // derrière.
+    player.lastApplied = NEUTRAL_INPUT;
+    player.pending.length = 0;
+
+    return [this.#lobbyMessage()];
+  }
+
+  /** Démarre la partie. Sans effet si elle a déjà commencé. */
+  start(): Outgoing[] {
+    if (this.#started) return [];
+
+    this.#started = true;
+    this.#runner = new CampaignRunner({ playerIds: [...this.#players.keys()] });
+
+    return [this.#lobbyMessage()];
+  }
+
+  /** Enregistre une intention. Le serveur ne lit jamais autre chose d'un client. */
+  input(playerId: string, message: InputMessage): void {
+    const player = this.#players.get(playerId);
+    if (!player) return;
+
+    // Une intention déjà dépassée est un doublon ou un message en retard :
+    // l'appliquer ferait reculer le tank.
+    if (message.seq <= player.ack) return;
+
+    player.pending.push(message);
+
+    // Un client qui inonderait la salle ne doit pas la faire gonfler sans fin.
+    if (player.pending.length > MAX_BUFFERED_INPUTS) {
+      player.pending.splice(0, player.pending.length - MAX_BUFFERED_INPUTS);
+    }
+  }
+
+  /* ── Simulation ───────────────────────────────────────────────────────── */
+
+  /** Avance la salle d'un pas. */
+  step(): void {
+    this.#tick++;
+
+    const runner = this.#runner;
+    if (!runner) return;
+
+    this.#dropExpiredPlayers(runner);
+
+    const intents = new Map<string, InputCommand>();
+    for (const player of this.#players.values()) {
+      intents.set(player.playerId, this.#nextInput(player));
+    }
+
+    runner.step(runner.inputsFor(intents));
+  }
+
+  /**
+   * Prélève l'intention du pas pour un joueur.
+   *
+   * Trois cas, et c'est tout le rôle du tampon anti-gigue :
+   *
+   *   - tampon vide → on rejoue la dernière intention connue. Un déplacement est
+   *     un état maintenu : le tank continue plutôt que de saccader ;
+   *   - tampon à la profondeur visée → on consomme une intention ;
+   *   - tampon trop rempli → on en consomme deux, pour résorber l'avance sans
+   *     jeter d'intention et sans laisser la latence s'installer.
+   */
+  #nextInput(player: Player): InputCommand {
+    let consumed = player.pending.shift();
+    if (!consumed) return player.lastApplied;
+
+    if (player.pending.length > TARGET_BUFFER_DEPTH) {
+      const extra = player.pending.shift();
+      if (extra) consumed = extra;
+    }
+
+    player.lastApplied = consumed.input;
+    player.ack = consumed.seq;
+    return consumed.input;
+  }
+
+  /** Retire les joueurs dont le délai de grâce a expiré. */
+  #dropExpiredPlayers(runner: CampaignRunner): void {
+    const grace = secondsToTicks(DISCONNECT_GRACE_SECONDS);
+
+    for (const player of [...this.#players.values()]) {
+      if (player.disconnectedAtTick === null) continue;
+      if (this.#tick - player.disconnectedAtTick < grace) continue;
+
+      this.#players.delete(player.playerId);
+      this.#terrainVersionSent.delete(player.playerId);
+      // L'IA et les autres joueurs ne s'en aperçoivent pas : seul le tank part.
+      runner.removePlayer(player.playerId);
+    }
+  }
+
+  /* ── Diffusion ────────────────────────────────────────────────────────── */
+
+  /**
+   * Compose les messages du prochain envoi.
+   *
+   * L'instantané est individuel malgré son contenu commun : chaque client a son
+   * propre accusé de réception et son propre tank à prédire.
+   */
+  broadcast(): Outgoing[] {
+    const runner = this.#runner;
+    if (!runner) return [];
+
+    const world = runner.world;
+    const messages: Outgoing[] = [];
+    const partial = stripTiles(world);
+
+    for (const player of this.#players.values()) {
+      if (!player.connected) continue;
+
+      // Le terrain ne repart qu'au changement de version : c'est de loin le
+      // plus gros objet de l'état, et il ne bouge qu'à la destruction d'un bloc
+      // ou au changement de mission.
+      if (this.#terrainVersionSent.get(player.playerId) !== world.grid.version) {
+        this.#terrainVersionSent.set(player.playerId, world.grid.version);
+        const terrain: TerrainMessage = { t: 'terrain', grid: world.grid };
+        messages.push({ to: player.playerId, message: terrain });
+      }
+
+      const snapshot: SnapshotMessage = {
+        t: 'snapshot',
+        // L'horloge de la salle, monotone, et non celle du monde qui repart de
+        // zéro à chaque mission.
+        tick: this.#tick,
+        ack: player.ack,
+        yourTankId: runner.tankIdOf(player.playerId) ?? null,
+        gridVersion: world.grid.version,
+        world: partial,
+        campaign: runner.campaign,
+      };
+
+      messages.push({ to: player.playerId, message: snapshot });
+    }
+
+    return messages;
+  }
+
+  /** Identifiant du tank d'un joueur, ou `undefined`. Sert aux tests. */
+  tankIdOf(playerId: string): EntityId | undefined {
+    return this.#runner?.tankIdOf(playerId);
+  }
+
+  #lobbyMessage(): Outgoing {
+    const players: LobbyPlayer[] = [...this.#players.values()].map((player) => ({
+      playerId: player.playerId,
+      name: player.name,
+      connected: player.connected,
+    }));
+
+    return { to: null, message: { t: 'lobby', room: this.name, players, started: this.#started } };
+  }
+}

--- a/src/server/loop.ts
+++ b/src/server/loop.ts
@@ -1,0 +1,71 @@
+/**
+ * Boucle serveur à pas fixe.
+ *
+ * Elle consomme le temps réel exactement comme le client, via le même
+ * {@link FixedTimestep} : c'est la condition pour que les deux comptent le même
+ * nombre de pas. Une seconde implémentation ici, et le serveur avancerait de
+ * 61 pas quand le client en compte 60 — la réconciliation corrigerait alors sans
+ * fin un écart qui ne vient pas du réseau.
+ *
+ * Le pilote change, en revanche : pas de `requestAnimationFrame` côté serveur,
+ * mais un minuteur.
+ */
+
+import { DT } from '@core/tick';
+import { FixedTimestep } from '@shared/timestep';
+import { SNAPSHOT_RATE } from '@shared/protocol';
+
+/**
+ * Période du minuteur, en millisecondes.
+ *
+ * Plus courte qu'un pas de simulation : `setInterval` n'est pas ponctuel, et
+ * l'interroger plus souvent que nécessaire permet à l'accumulateur de rattraper
+ * la dérive au lieu de la subir.
+ */
+const TIMER_PERIOD_MS = (DT * 1000) / 2;
+
+export interface ServerLoopHandlers {
+  /** Appelé exactement une fois par pas de simulation. */
+  step(): void;
+  /** Appelé à la fréquence de diffusion des instantanés. */
+  broadcast(): void;
+}
+
+export interface RunningServerLoop {
+  stop(): void;
+}
+
+/** Démarre la boucle. Rend de quoi l'arrêter, ce dont les tests ont besoin. */
+export function startServerLoop(handlers: ServerLoopHandlers): RunningServerLoop {
+  const timestep = new FixedTimestep();
+  const ticksPerSnapshot = Math.round(1 / (SNAPSHOT_RATE * DT));
+
+  let previousMs = performance.now();
+  let ticksSinceSnapshot = 0;
+
+  const timer = setInterval(() => {
+    const nowMs = performance.now();
+    const elapsedSeconds = (nowMs - previousMs) / 1000;
+    previousMs = nowMs;
+
+    const ticks = timestep.advance(elapsedSeconds);
+
+    for (let index = 0; index < ticks; index++) {
+      handlers.step();
+      ticksSinceSnapshot++;
+
+      // Compté en pas et non en millisecondes : la cadence de diffusion reste
+      // ainsi accrochée à la simulation, y compris après un rattrapage.
+      if (ticksSinceSnapshot >= ticksPerSnapshot) {
+        ticksSinceSnapshot = 0;
+        handlers.broadcast();
+      }
+    }
+  }, TIMER_PERIOD_MS);
+
+  return {
+    stop(): void {
+      clearInterval(timer);
+    },
+  };
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,0 +1,164 @@
+/**
+ * Serveur de jeu : fichiers statiques et WebSocket, sans aucune dépendance.
+ *
+ * `Bun.serve` fait les deux. L'ancienne version demandait `ws`, `concurrently`
+ * et un second script Node pour servir les fichiers ; il n'en reste rien.
+ *
+ *     bun run serve            # port 3000 par défaut
+ *     PORT=8080 bun run serve
+ *
+ * En développement, Vite sert le client et ce serveur ne fait que le jeu : le
+ * client s'y connecte par `?enligne=1`. En production, `bun run build` remplit
+ * `dist/`, que ce serveur sert lui-même.
+ */
+
+import { PROTOCOL_VERSION, decode, encode } from '@shared/protocol';
+import type { ClientMessage } from '@shared/protocol';
+import { Room } from './Room';
+import { startServerLoop } from './loop';
+
+/** Données attachées à chaque socket. */
+interface SocketData {
+  playerId: string;
+  room: string;
+}
+
+const PORT = Number(process.env['PORT'] ?? 3000);
+
+/** Racine des fichiers statiques. Absente tant que `bun run build` n'a pas tourné. */
+const STATIC_ROOT = new URL('../../dist/', import.meta.url).pathname;
+
+const rooms = new Map<string, Room>();
+
+/** Sockets ouvertes, par identifiant de joueur. */
+const sockets = new Map<string, Bun.ServerWebSocket<SocketData>>();
+
+function roomFor(name: string): Room {
+  const existing = rooms.get(name);
+  if (existing) return existing;
+
+  const created = new Room(name);
+  rooms.set(name, created);
+  return created;
+}
+
+/** Achemine les messages qu'une salle veut émettre. */
+function dispatch(room: Room, outgoing: ReturnType<Room['broadcast']>): void {
+  for (const { to, message } of outgoing) {
+    const payload = encode(message);
+
+    if (to !== null) {
+      sockets.get(to)?.send(payload);
+      continue;
+    }
+
+    // Diffusion : le serveur publie sur le sujet du salon plutôt que de
+    // parcourir la liste des sockets, ce que Bun sait faire nativement.
+    server.publish(room.name, payload);
+  }
+}
+
+const server = Bun.serve<SocketData>({
+  port: PORT,
+
+  async fetch(request, bunServer) {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/ws') {
+      // L'identité vient de l'URL et non du premier message : il faut la
+      // connaître avant même que le socket s'ouvre, pour pouvoir rattacher une
+      // reconnexion à son siège.
+      const playerId = url.searchParams.get('joueur') ?? crypto.randomUUID();
+      const room = url.searchParams.get('salon') ?? 'principal';
+
+      if (bunServer.upgrade(request, { data: { playerId, room } })) return undefined;
+      return new Response('Échec de la bascule en WebSocket', { status: 400 });
+    }
+
+    // Fichiers statiques. Toute route inconnue rend `index.html` : le client
+    // est une application d'une seule page.
+    const path = url.pathname === '/' ? '/index.html' : url.pathname;
+    const file = Bun.file(STATIC_ROOT + path.replace(/^\//, ''));
+
+    if (await file.exists()) return new Response(file);
+
+    const index = Bun.file(`${STATIC_ROOT}index.html`);
+    if (await index.exists()) return new Response(index);
+
+    return new Response(
+      'Client non construit. Lancez `bun run build`, ou `bun run dev` pour le mode développement.',
+      { status: 404 },
+    );
+  },
+
+  websocket: {
+    open(ws) {
+      ws.subscribe(ws.data.room);
+    },
+
+    message(ws, raw) {
+      const message = decode<ClientMessage>(typeof raw === 'string' ? raw : raw.toString());
+      // Un pair distant peut envoyer n'importe quoi : un message illisible est
+      // ignoré, jamais une cause d'interruption.
+      if (!message) return;
+
+      const room = roomFor(ws.data.room);
+
+      switch (message.t) {
+        case 'join': {
+          if (message.version !== PROTOCOL_VERSION) {
+            ws.send(encode({ t: 'bye', reason: 'Version de protocole incompatible' }));
+            ws.close();
+            return;
+          }
+
+          sockets.set(ws.data.playerId, ws);
+          dispatch(room, room.join(ws.data.playerId, message.name));
+
+          // Le premier arrivant lance la partie : en co-op, attendre un signal
+          // explicite pour jouer seul n'apporterait rien.
+          if (!room.started) dispatch(room, room.start());
+          break;
+        }
+
+        case 'start':
+          dispatch(room, room.start());
+          break;
+
+        case 'input':
+          room.input(ws.data.playerId, message);
+          break;
+      }
+    },
+
+    close(ws) {
+      sockets.delete(ws.data.playerId);
+
+      const room = rooms.get(ws.data.room);
+      if (!room) return;
+
+      dispatch(room, room.disconnect(ws.data.playerId));
+    },
+  },
+});
+
+startServerLoop({
+  step(): void {
+    for (const room of rooms.values()) room.step();
+  },
+
+  broadcast(): void {
+    for (const [name, room] of rooms) {
+      // Une salle vidée de ses joueurs ne doit pas continuer à simuler
+      // indéfiniment : elle serait retenue en mémoire jusqu'à l'arrêt du serveur.
+      if (room.isEmpty) {
+        rooms.delete(name);
+        continue;
+      }
+
+      dispatch(room, room.broadcast());
+    }
+  },
+});
+
+console.log(`Tanks! — serveur sur http://localhost:${PORT} (WebSocket sur /ws)`);

--- a/src/shared/CampaignRunner.ts
+++ b/src/shared/CampaignRunner.ts
@@ -1,0 +1,196 @@
+/**
+ * Orchestration d'une campagne : enchaîne les missions, gère la réserve de tanks.
+ *
+ * ─── Pourquoi dans `shared/` ────────────────────────────────────────────────
+ *
+ * Parce que le serveur (#13) et le client solo doivent enchaîner les missions
+ * **exactement** de la même façon. Une seconde implémentation côté serveur, et
+ * les deux dériveraient — c'est précisément le défaut de l'ancienne version,
+ * qui avait deux chemins de code pour le solo et l'en-ligne.
+ *
+ * Répartition des rôles, inchangée :
+ *
+ *   - `core/systems/mission.ts` **juge** l'issue d'un monde (lecture pure) ;
+ *   - `shared/campaign.ts` **décide** de la suite (réducteur pur) ;
+ *   - cette classe **orchestre** : elle tient le monde courant, compte le temps
+ *     mort entre deux missions, et charge la suivante.
+ *
+ * Elle ne connaît ni le rendu, ni le réseau, ni les entrées : elle reçoit des
+ * intentions déjà formées et fait avancer un monde.
+ */
+
+import type { EntityId, InputCommand, Tank, World } from '@core/state';
+import { missionOutcome } from '@core/systems/mission';
+import type { MissionOutcome } from '@core/systems/mission';
+import { secondsToTicks, tick } from '@core/tick';
+import type { TickInputs } from '@core/tick';
+import { advanceCampaign, startCampaign } from './campaign';
+import type { CampaignState } from './campaign';
+import { loadMission } from './missions/load';
+import { missionByNumber } from './missions/missions';
+
+/**
+ * Temps mort après une mission réussie, en secondes.
+ *
+ * La simulation continue d'avancer pendant ce délai : l'explosion du dernier
+ * ennemi doit se jouer entièrement, sinon la mission se coupe sur une image
+ * figée et le coup gagnant n'est jamais vu.
+ */
+const CLEARED_PAUSE_SECONDS = 1.6;
+
+/** Temps mort après un échec. Un peu plus long : il y a une mauvaise nouvelle à lire. */
+const FAILED_PAUSE_SECONDS = 2.2;
+
+export interface CampaignRunnerOptions {
+  /** Joueurs présents au départ, dans l'ordre des sièges. */
+  playerIds: readonly string[];
+  /** Mission de départ, à partir de 1. */
+  startingMission?: number;
+}
+
+export class CampaignRunner {
+  #state: CampaignState;
+  #world: World;
+  /** Tank de chaque joueur dans le monde courant. */
+  #tankByPlayer = new Map<string, EntityId>();
+
+  readonly #playerIds: string[];
+
+  /**
+   * Pas restants avant de charger la mission suivante.
+   *
+   * Un décompte plutôt qu'une date : la transition reste ainsi indépendante de
+   * la fréquence d'affichage, comme le reste de la simulation.
+   */
+  #pauseTicks = 0;
+
+  constructor({ playerIds, startingMission = 1 }: CampaignRunnerOptions) {
+    this.#playerIds = [...playerIds];
+    this.#state = startCampaign(startingMission);
+    this.#world = this.#openMission();
+  }
+
+  get world(): World {
+    return this.#world;
+  }
+
+  get campaign(): CampaignState {
+    return this.#state;
+  }
+
+  /** Issue de la mission en cours, recalculée à la demande. */
+  get outcome(): MissionOutcome {
+    return missionOutcome(this.#world);
+  }
+
+  /** Joueurs installés, dans l'ordre des sièges. */
+  get playerIds(): readonly string[] {
+    return this.#playerIds;
+  }
+
+  tankOf(playerId: string): Tank | undefined {
+    const id = this.#tankByPlayer.get(playerId);
+    return id === undefined ? undefined : this.#world.tanks.find((tank) => tank.id === id);
+  }
+
+  tankIdOf(playerId: string): EntityId | undefined {
+    return this.#tankByPlayer.get(playerId);
+  }
+
+  /**
+   * Installe un joueur en cours de partie.
+   *
+   * Le co-op se joue en arrivée libre : un nouveau venu reçoit un tank tout de
+   * suite plutôt que d'attendre la mission suivante. S'il était déjà là, on ne
+   * fait que rendre son siège.
+   */
+  addPlayer(playerId: string): EntityId | undefined {
+    const existing = this.#tankByPlayer.get(playerId);
+    if (existing !== undefined) return existing;
+
+    this.#playerIds.push(playerId);
+    // Rouvrir la mission est le seul moyen d'obtenir un point de départ valide
+    // et un monde cohérent : les positions de départ appartiennent à la mission.
+    this.#world = this.#openMission();
+    return this.#tankByPlayer.get(playerId);
+  }
+
+  /** Retire un joueur et son tank. Les autres et l'IA continuent sans interruption. */
+  removePlayer(playerId: string): void {
+    const tankId = this.#tankByPlayer.get(playerId);
+    this.#tankByPlayer.delete(playerId);
+
+    const index = this.#playerIds.indexOf(playerId);
+    if (index !== -1) this.#playerIds.splice(index, 1);
+
+    if (tankId === undefined) return;
+    this.#world.tanks = this.#world.tanks.filter((tank) => tank.id !== tankId);
+  }
+
+  /** Recommence la campagne depuis la première mission. */
+  restart(): void {
+    this.#state = startCampaign();
+    this.#pauseTicks = 0;
+    this.#world = this.#openMission();
+  }
+
+  /**
+   * Avance d'un pas, et enchaîne les missions le moment venu.
+   *
+   * @param inputs intentions des joueurs pour ce pas, par identifiant de tank
+   */
+  step(inputs: TickInputs): void {
+    tick(this.#world, inputs);
+
+    // Campagne terminée : le monde continue de tourner en toile de fond, mais
+    // plus aucune transition n'est déclenchée.
+    if (this.#state.status !== 'playing') return;
+
+    if (this.#pauseTicks > 0) {
+      this.#pauseTicks--;
+      if (this.#pauseTicks === 0) this.#resolve();
+      return;
+    }
+
+    const outcome = missionOutcome(this.#world);
+    if (outcome === 'playing') return;
+
+    this.#pauseTicks = secondsToTicks(
+      outcome === 'cleared' ? CLEARED_PAUSE_SECONDS : FAILED_PAUSE_SECONDS,
+    );
+  }
+
+  /** Construit les entrées d'un pas à partir des intentions par joueur. */
+  inputsFor(byPlayer: ReadonlyMap<string, InputCommand>): TickInputs {
+    const inputs: Array<readonly [EntityId, InputCommand]> = [];
+
+    for (const [playerId, input] of byPlayer) {
+      const tankId = this.#tankByPlayer.get(playerId);
+      if (tankId !== undefined) inputs.push([tankId, input]);
+    }
+
+    return inputs;
+  }
+
+  /* ── Enchaînement ────────────────────────────────────────────────────── */
+
+  /** Applique l'issue de la mission écoulée et ouvre la suivante s'il y en a une. */
+  #resolve(): void {
+    this.#state = advanceCampaign(this.#state, missionOutcome(this.#world));
+    if (this.#state.status === 'playing') this.#world = this.#openMission();
+  }
+
+  /** Charge la mission courante dans un monde neuf. */
+  #openMission(): World {
+    const mission = missionByNumber(this.#state.mission);
+    if (!mission) throw new Error(`Mission ${this.#state.mission} inexistante`);
+
+    const { world, playerTankIds } = loadMission(mission, { playerIds: this.#playerIds });
+
+    this.#tankByPlayer = new Map(
+      this.#playerIds.map((playerId, index) => [playerId, playerTankIds[index]!]),
+    );
+
+    return world;
+  }
+}

--- a/src/shared/missions/load.ts
+++ b/src/shared/missions/load.ts
@@ -7,10 +7,12 @@
  * positions de départ des deux côtés.
  */
 
-import type { EntityId, World } from '@core/state';
+import { blocksTank, tileAt } from '@core/grid';
+import type { EntityId, Grid, World } from '@core/state';
 import { createTank, createWorld } from '@core/world';
 import type { Mission } from './missions';
 import { MissionParseError, parseMission } from './parse';
+import type { SpawnPoint } from './parse';
 
 export interface LoadMissionOptions {
   /**
@@ -34,14 +36,97 @@ export interface LoadedMission {
   playerTankIds: EntityId[];
 }
 
+/**
+ * Complète les points de départ manquants par des tuiles voisines du premier.
+ *
+ * ─── Pourquoi dériver plutôt que déclarer ───────────────────────────────────
+ *
+ * L'original est un jeu solo : ses arènes n'ont qu'un point de départ, et les
+ * vingt grilles le reflètent. Le co-op est un ajout de cette refonte, pas une
+ * caractéristique du jeu de référence — dessiner à la main trois départs de
+ * plus sur vingt arènes reviendrait à inventer vingt fois une donnée que
+ * personne n'a mesurée, avec vingt occasions de placer un coéquipier dans un
+ * mur ou sous le nez d'un tank vert.
+ *
+ * Les coéquipiers apparaissent donc **autour** du départ d'origine : c'est le
+ * comportement attendu d'un co-op, et ça hérite gratuitement des vérifications
+ * déjà faites sur ce point de départ — accessibilité et distance aux ennemis.
+ *
+ * Le parcours en largeur est déterministe, ordre des voisins compris : deux
+ * chargements de la même mission placent les mêmes joueurs aux mêmes tuiles,
+ * serveur et client compris. `parseMission` accepte toujours `2`, `3` et `4`
+ * si une arène veut fixer ses départs explicitement.
+ */
+function deriveSpawns(grid: Grid, known: readonly SpawnPoint[], needed: number): SpawnPoint[] {
+  const spawns = [...known];
+  if (spawns.length >= needed) return spawns;
+
+  const origin = spawns[0]!;
+  const start = { x: Math.floor(origin.x), y: Math.floor(origin.y) };
+
+  const seen = new Set([`${start.x},${start.y}`]);
+  const queue = [start];
+
+  while (queue.length > 0 && spawns.length < needed) {
+    const current = queue.shift()!;
+
+    // Ordre fixe, et sans diagonale : la boîte du tank ne passe pas entre deux
+    // blocs qui se touchent par le coin.
+    for (const [dx, dy] of [
+      [1, 0],
+      [0, 1],
+      [-1, 0],
+      [0, -1],
+    ] as const) {
+      const x = current.x + dx;
+      const y = current.y + dy;
+      const key = `${x},${y}`;
+
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      if (blocksTank(tileAt(grid, x, y))) continue;
+      queue.push({ x, y });
+
+      if (spawns.length >= needed) continue;
+
+      const candidate: SpawnPoint = { x: x + 0.5, y: y + 0.5 };
+      if (isCrowded(candidate, spawns)) continue;
+
+      spawns.push(candidate);
+    }
+  }
+
+  return spawns;
+}
+
+/**
+ * Écart minimal entre deux places de départ, en tuiles.
+ *
+ * Sans cette contrainte, le parcours en largeur prend les tuiles voisines
+ * immédiates et les coéquipiers apparaissent collés les uns aux autres : les
+ * boîtes de collision se touchent, et le premier qui veut partir dans la
+ * mauvaise direction reste bloqué contre son voisin.
+ */
+const MIN_SPAWN_SEPARATION_TILES = 2;
+
+function isCrowded(candidate: SpawnPoint, taken: readonly SpawnPoint[]): boolean {
+  return taken.some(
+    (spawn) =>
+      Math.hypot(spawn.x - candidate.x, spawn.y - candidate.y) < MIN_SPAWN_SEPARATION_TILES,
+  );
+}
+
 /** Instancie le terrain, les joueurs et les ennemis d'une mission. */
 export function loadMission(mission: Mission, options: LoadMissionOptions): LoadedMission {
   const { playerIds, seed = mission.id } = options;
   const parsed = parseMission(mission.grid);
 
-  if (playerIds.length > parsed.playerSpawns.length) {
+  const playerSpawns = deriveSpawns(parsed.grid, parsed.playerSpawns, playerIds.length);
+
+  if (playerIds.length > playerSpawns.length) {
     throw new MissionParseError(
-      `mission ${mission.id} : ${playerIds.length} joueurs pour ${parsed.playerSpawns.length} points de départ`,
+      `mission ${mission.id} : ${playerIds.length} joueurs, et pas assez de place autour du départ`,
     );
   }
 
@@ -54,7 +139,7 @@ export function loadMission(mission: Mission, options: LoadMissionOptions): Load
   world.grid = parsed.grid;
 
   const playerTankIds = playerIds.map((playerId, index) => {
-    const spawn = parsed.playerSpawns[index]!;
+    const spawn = playerSpawns[index]!;
     return createTank(world, { color: 'player', playerId, x: spawn.x, y: spawn.y }).id;
   });
 

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -1,0 +1,201 @@
+/**
+ * Messages échangés entre client et serveur.
+ *
+ * ─── Le principe qui gouverne tout ce fichier ───────────────────────────────
+ *
+ * **Le client n'envoie que des intentions, jamais un état.** Pas de position,
+ * pas de vitesse, pas de « j'ai touché ». Un client malveillant ne peut donc
+ * pas se téléporter ni s'attribuer une victoire : au mieux, il envoie des
+ * intentions absurdes, que le serveur applique — et les règles s'appliquent à
+ * lui comme aux autres.
+ *
+ * L'ancienne version faisait l'inverse : elle diffusait les coordonnées, et le
+ * serveur relayait sans lire. Tricher revenait à éditer un champ.
+ *
+ * ─── Ce qui circule dans l'autre sens ───────────────────────────────────────
+ *
+ * Le serveur diffuse l'état complet du monde à 20 Hz, **sauf le terrain**, qui
+ * ne change qu'à la destruction d'un bloc. Le terrain part à part, quand son
+ * numéro de version bouge : c'est de loin le plus gros objet de l'état, et le
+ * renvoyer soixante fois par seconde pour rien multiplierait le débit par cinq.
+ */
+
+import type { Grid, InputCommand, TileKind, World } from '@core/state';
+import type { TankProfile } from '@core/systems/ai/profiles';
+import type { TankColor } from '@core/state';
+import type { Tuning } from '@core/tuning';
+import type { CampaignState } from './campaign';
+
+/** Version du protocole. Un client d'une autre version est refusé à la porte. */
+export const PROTOCOL_VERSION = 1;
+
+/** Fréquence de diffusion des instantanés, en hertz. */
+export const SNAPSHOT_RATE = 20;
+
+/**
+ * Retard d'interpolation des entités distantes, en secondes.
+ *
+ * Un peu plus que l'intervalle entre deux instantanés (50 ms) : il faut avoir
+ * reçu le suivant pour interpoler vers lui. Trop court, le client manque de
+ * données et fige ; trop long, tout le monde joue dans le passé.
+ */
+export const INTERPOLATION_DELAY_SECONDS = 0.1;
+
+/* ── Client → serveur ───────────────────────────────────────────────────── */
+
+/** Demande d'entrée dans un salon. */
+export interface JoinMessage {
+  t: 'join';
+  version: number;
+  /** Salon visé. Créé s'il n'existe pas. */
+  room: string;
+  /** Nom affiché dans le lobby. */
+  name: string;
+}
+
+/**
+ * Intention pour un pas.
+ *
+ * `seq` est le numéro de pas **du client**. Le serveur le renvoie tel quel dans
+ * son accusé de réception, ce qui permet au client de savoir quelles intentions
+ * sont déjà prises en compte et lesquelles il doit rejouer.
+ */
+export interface InputMessage {
+  t: 'input';
+  seq: number;
+  input: InputCommand;
+}
+
+/** Demande de démarrage de la partie. N'importe quel joueur du salon peut la faire. */
+export interface StartMessage {
+  t: 'start';
+}
+
+export type ClientMessage = JoinMessage | InputMessage | StartMessage;
+
+/* ── Serveur → client ───────────────────────────────────────────────────── */
+
+/**
+ * Accueil.
+ *
+ * Contient la **table de réglages du serveur** : la prédiction du client doit
+ * tourner sur exactement les mêmes constantes que l'autorité, sinon elle
+ * dérive à chaque pas et se fait corriger en permanence. C'est le serveur qui
+ * fait foi, y compris sur les réglages.
+ */
+export interface WelcomeMessage {
+  t: 'welcome';
+  playerId: string;
+  room: string;
+  tickRate: number;
+  snapshotRate: number;
+  tuning: Tuning;
+  profiles: Record<TankColor, TankProfile>;
+}
+
+/** Un joueur du salon, tel qu'affiché dans le lobby. */
+export interface LobbyPlayer {
+  playerId: string;
+  name: string;
+  connected: boolean;
+}
+
+export interface LobbyMessage {
+  t: 'lobby';
+  room: string;
+  players: LobbyPlayer[];
+  started: boolean;
+}
+
+/**
+ * Terrain de la mission courante.
+ *
+ * Envoyé à la connexion, puis seulement quand `version` change — c'est-à-dire
+ * à une destruction de bloc ou à un changement de mission.
+ */
+export interface TerrainMessage {
+  t: 'terrain';
+  grid: Grid;
+}
+
+/**
+ * État du monde à un pas donné, terrain exclu.
+ *
+ * `ack` est le `seq` de la dernière intention du destinataire prise en compte.
+ * Chaque client en reçoit donc un différent : l'instantané est diffusé, cette
+ * valeur ne l'est pas.
+ */
+export interface SnapshotMessage {
+  t: 'snapshot';
+  /**
+   * Horloge **monotone** de la salle, en pas.
+   *
+   * Et non `world.tick`, qui repart de zéro à chaque mission : le client s'en
+   * sert de base de temps pour interpoler les entités distantes, et une horloge
+   * qui recule ferait sauter cette interpolation à chaque changement d'arène.
+   */
+  tick: number;
+  ack: number;
+  /** Tank du destinataire, pour qu'il sache lequel prédire. */
+  yourTankId: number | null;
+  /** Version du terrain courant, pour détecter un `terrain` manquant. */
+  gridVersion: number;
+  /** Le monde, sans les tuiles. */
+  world: WorldWithoutTiles;
+  campaign: CampaignState;
+}
+
+/** Le monde amputé des tuiles de terrain, qui voyagent séparément. */
+export type WorldWithoutTiles = Omit<World, 'grid'> & {
+  grid: Omit<Grid, 'tiles'>;
+};
+
+/** Fin de connexion à l'initiative du serveur. */
+export interface ByeMessage {
+  t: 'bye';
+  reason: string;
+}
+
+export type ServerMessage =
+  | WelcomeMessage
+  | LobbyMessage
+  | TerrainMessage
+  | SnapshotMessage
+  | ByeMessage;
+
+/* ── (Dé)sérialisation ──────────────────────────────────────────────────── */
+
+export function encode(message: ClientMessage | ServerMessage): string {
+  return JSON.stringify(message);
+}
+
+/**
+ * Décode un message reçu.
+ *
+ * Rend `null` sur tout ce qui n'a pas la forme attendue, plutôt que de lever :
+ * un pair distant peut envoyer n'importe quoi, y compris du binaire ou du JSON
+ * tronqué, et ça ne doit jamais interrompre la boucle de jeu.
+ */
+export function decode<T extends ClientMessage | ServerMessage>(raw: unknown): T | null {
+  if (typeof raw !== 'string') return null;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    if (typeof (parsed as { t?: unknown }).t !== 'string') return null;
+    return parsed as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Sépare le monde de ses tuiles, pour la diffusion. */
+export function stripTiles(world: World): WorldWithoutTiles {
+  const { tiles: _tiles, ...grid } = world.grid;
+  return { ...world, grid };
+}
+
+/** Recompose un monde complet à partir d'un instantané et du terrain connu. */
+export function withTiles(partial: WorldWithoutTiles, tiles: TileKind[]): World {
+  return { ...partial, grid: { ...partial.grid, tiles } };
+}

--- a/src/shared/timestep.ts
+++ b/src/shared/timestep.ts
@@ -1,0 +1,76 @@
+/**
+ * Cadencement à pas de temps fixe.
+ *
+ * La simulation avance par pas de `DT` exactement, quelle que soit la fréquence
+ * qui pilote la boucle : `requestAnimationFrame` côté client, un minuteur côté
+ * serveur (#13). Le rendu, lui, s'exécute à la fréquence de l'écran et interpole
+ * entre le dernier état simulé et le précédent grâce au résidu `alpha`.
+ *
+ * Ce module vit dans `shared/` parce que **client et serveur doivent consommer
+ * le temps réel de la même façon**. Une seconde implémentation côté serveur, et
+ * les deux dériveraient — le serveur avancerait de 61 pas quand le client en
+ * compte 60, et la réconciliation corrigerait sans fin un écart qui ne vient
+ * pas du réseau.
+ *
+ * L'accumulateur ne touche à rien de spécifique au navigateur : c'est la partie
+ * qui contient la logique délicate, et elle doit être testable en headless.
+ */
+
+import { DT } from '@core/tick.js';
+
+/**
+ * Nombre maximal de pas rattrapés en une passe.
+ *
+ * Sans ce plafond, un gel de l'onglet de dix secondes demanderait 600 pas d'un
+ * coup ; le rattrapage prendrait plus de temps que le retard accumulé, ce qui
+ * creuserait encore l'écart — la « spirale de la mort ». Au-delà du plafond, on
+ * abandonne le retard : mieux vaut un saut visible qu'un blocage définitif.
+ */
+export const MAX_CATCHUP_TICKS = 5;
+
+/** Durée maximale prise en compte pour une frame, en secondes. */
+export const MAX_FRAME_SECONDS = MAX_CATCHUP_TICKS * DT;
+
+export class FixedTimestep {
+  /** Temps accumulé pas encore converti en pas de simulation, en secondes. */
+  #accumulator = 0;
+
+  /** Fraction de pas restante, dans [0, 1). Sert à interpoler le rendu. */
+  #alpha = 0;
+
+  /**
+   * Absorbe le temps réel écoulé et rend le nombre de pas de simulation à
+   * exécuter.
+   *
+   * @param elapsedSeconds temps écoulé depuis l'appel précédent
+   * @returns nombre de pas à exécuter, entre 0 et {@link MAX_CATCHUP_TICKS}
+   */
+  advance(elapsedSeconds: number): number {
+    // On borne l'entrée plutôt que le nombre de pas : le temps excédentaire ne
+    // doit pas rester dans l'accumulateur, sinon il ressortirait à la frame
+    // suivante et le rattrapage recommencerait indéfiniment.
+    const clamped = Math.min(Math.max(elapsedSeconds, 0), MAX_FRAME_SECONDS);
+
+    this.#accumulator += clamped;
+
+    let ticks = 0;
+    while (this.#accumulator >= DT) {
+      this.#accumulator -= DT;
+      ticks++;
+    }
+
+    this.#alpha = this.#accumulator / DT;
+    return ticks;
+  }
+
+  /** Résidu d'interpolation courant, dans [0, 1). */
+  get alpha(): number {
+    return this.#alpha;
+  }
+
+  /** Remet l'accumulateur à zéro, par exemple au chargement d'une mission. */
+  reset(): void {
+    this.#accumulator = 0;
+    this.#alpha = 0;
+  }
+}

--- a/tests/fixed-timestep.test.ts
+++ b/tests/fixed-timestep.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { FixedTimestep, MAX_CATCHUP_TICKS, MAX_FRAME_SECONDS } from '../src/client/loop.js';
+import { FixedTimestep, MAX_CATCHUP_TICKS, MAX_FRAME_SECONDS } from '../src/shared/timestep.js';
 import { DT, TICK_RATE } from '../src/core/tick.js';
 
 /**

--- a/tests/missions.test.ts
+++ b/tests/missions.test.ts
@@ -294,10 +294,60 @@ describe('chargement d\'une mission', () => {
     expect(first.world.tanks).toEqual(second.world.tanks);
   });
 
-  test('demander plus de joueurs que de départs est refusé', () => {
-    expect(() => loadMission(MISSIONS[0]!, { playerIds: ['p1', 'p2'] })).toThrow(
-      /points de départ/,
-    );
+  test('les coéquipiers apparaissent autour du départ déclaré', () => {
+    // L'original est un jeu solo : ses arènes n'ont qu'un point de départ. Le
+    // co-op est un ajout de cette refonte, et les places manquantes sont
+    // dérivées des tuiles voisines plutôt qu'inventées sur vingt grilles.
+    const { world } = loadMission(MISSIONS[0]!, { playerIds: ['p1', 'p2', 'p3', 'p4'] });
+    const players = world.tanks.filter((tank) => tank.playerId !== null);
+
+    expect(players).toHaveLength(4);
+
+    const declared = parseMission(MISSIONS[0]!.grid).playerSpawns[0]!;
+    for (const tank of players) {
+      // Assez près pour hériter des garanties du départ d'origine :
+      // accessibilité et distance aux ennemis.
+      expect(Math.hypot(tank.x - declared.x, tank.y - declared.y)).toBeLessThanOrEqual(6);
+    }
+  });
+
+  test('les coéquipiers ne se gênent pas au départ', () => {
+    // Deux tanks posés sur des tuiles voisines se touchent par leurs boîtes de
+    // collision : le premier qui part dans la mauvaise direction reste bloqué
+    // contre son voisin, et croit à un bug de pilotage.
+    for (const mission of MISSIONS) {
+      const { world } = loadMission(mission, { playerIds: ['p1', 'p2', 'p3', 'p4'] });
+      const players = world.tanks.filter((tank) => tank.playerId !== null);
+
+      for (const tank of players) {
+        for (const other of players) {
+          if (other.id === tank.id) continue;
+          expect(Math.hypot(other.x - tank.x, other.y - tank.y)).toBeGreaterThanOrEqual(
+            TUNING.tank.sizeTiles * 2,
+          );
+        }
+      }
+    }
+  });
+
+  test('les places dérivées sont sur du sol libre, dans toutes les missions', () => {
+    for (const mission of MISSIONS) {
+      const { world } = loadMission(mission, { playerIds: ['p1', 'p2', 'p3', 'p4'] });
+
+      for (const tank of world.tanks.filter((each) => each.playerId !== null)) {
+        const kind = tileAt(world.grid, Math.floor(tank.x), Math.floor(tank.y));
+        expect(blocksTank(kind)).toBe(false);
+      }
+    }
+  });
+
+  test('la dérivation est déterministe', () => {
+    // Serveur et client chargent la même mission chacun de leur côté : deux
+    // placements différents rendraient la réconciliation impossible.
+    const first = loadMission(MISSIONS[8]!, { playerIds: ['p1', 'p2', 'p3'] });
+    const second = loadMission(MISSIONS[8]!, { playerIds: ['p1', 'p2', 'p3'] });
+
+    expect(first.world.tanks).toEqual(second.world.tanks);
   });
 
   test('les vingt missions se chargent sans erreur', () => {

--- a/tests/netcode.test.ts
+++ b/tests/netcode.test.ts
@@ -1,0 +1,550 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { InputCommand, TileKind } from '../src/core/state.js';
+import { NEUTRAL_INPUT } from '../src/core/state.js';
+import { DT } from '../src/core/tick.js';
+import { TUNING } from '../src/core/tuning.js';
+import { hashWorld } from '../src/core/world.js';
+import { Reconciler } from '../src/client/net/reconciler.js';
+import { Room } from '../src/server/Room.js';
+import type { Outgoing } from '../src/server/Room.js';
+import { decode, encode, stripTiles, withTiles } from '../src/shared/protocol.js';
+import type { ClientMessage, ServerMessage, SnapshotMessage } from '../src/shared/protocol.js';
+
+/**
+ * Le co-op ne repose sur aucun code de gameplay nouveau — c'était tout l'objet
+ * de l'architecture. Ce qui est vérifié ici est donc l'autorité et la
+ * réconciliation, pas la physique.
+ *
+ * Ces tests n'ouvrent aucun socket : `Room` ne connaît pas le transport, elle
+ * reçoit des messages décodés et rend des messages à envoyer. C'est
+ * précisément ce qui les rend rapides et déterministes.
+ */
+
+/**
+ * Distance parcourue par un tank en un pas, en tuiles.
+ *
+ * Les seuils de saut s'expriment en multiples de cette valeur plutôt qu'en
+ * nombres absolus : un réglage de vitesse ne doit pas faire échouer un test de
+ * réseau.
+ */
+const MOVEMENT_STEP_TILES = TUNING.tank.speedTilesPerSecond * DT;
+
+/** Intention de déplacement vers la droite, tourelle à l'horizontale. */
+const RIGHT: InputCommand = { ...NEUTRAL_INPUT, moveX: 1 };
+const LEFT: InputCommand = { ...NEUTRAL_INPUT, moveX: -1 };
+
+/** Récupère les instantanés destinés à un joueur. */
+function snapshotsFor(outgoing: Outgoing[], playerId: string): SnapshotMessage[] {
+  return outgoing
+    .filter((entry) => entry.to === playerId && entry.message.t === 'snapshot')
+    .map((entry) => entry.message as SnapshotMessage);
+}
+
+/** Ouvre une salle avec les joueurs donnés, partie démarrée. */
+function openRoom(...playerIds: string[]): Room {
+  const room = new Room('essai');
+  for (const playerId of playerIds) room.join(playerId, playerId);
+  room.start();
+  return room;
+}
+
+/**
+ * Client d'essai : la partie de `NetworkSession` qui touche au réseau, sans le
+ * rendu.
+ *
+ * ⚠ Le passage par `encode` / `decode` n'est pas décoratif. `stripTiles` ne fait
+ * qu'un étalement superficiel : sans aller-retour JSON, les tableaux `tanks`,
+ * `shells` et `mines` restent **partagés** entre la salle et le client. Le
+ * client mutait alors l'état du serveur en rejouant ses intentions, et les
+ * tests de convergence vérifiaient que deux références égales sont égales —
+ * c'est-à-dire rien. Le réseau sérialise ; le test doit sérialiser aussi.
+ */
+class TestClient {
+  readonly reconciler = new Reconciler();
+  #tiles: TileKind[] | null = null;
+  #seq = 0;
+
+  /** Numéro de la prochaine intention. */
+  nextSeq(): number {
+    return this.#seq++;
+  }
+
+  /** Consomme des messages déjà sérialisés, exactement comme le vrai client. */
+  receiveWire(payloads: readonly string[]): void {
+    for (const payload of payloads) {
+      const wire = decode<ServerMessage>(payload);
+      if (!wire) continue;
+
+      if (wire.t === 'terrain') this.#tiles = wire.grid.tiles;
+
+      if (wire.t === 'snapshot' && this.#tiles) {
+        this.reconciler.reconcile(withTiles(wire.world, this.#tiles), wire.ack, wire.yourTankId);
+      }
+    }
+  }
+
+  /** Raccourci pour une livraison immédiate, sans lien simulé. */
+  receive(outgoing: Outgoing[], playerId: string): void {
+    this.receiveWire(toWire(outgoing, playerId));
+  }
+
+  /** Position du tank piloté, ou `null` avant le premier instantané. */
+  localTank(): { x: number; y: number } | null {
+    const world = this.reconciler.world;
+    const id = this.reconciler.localTankId;
+    if (!world || id === null) return null;
+
+    const tank = world.tanks.find((each) => each.id === id);
+    return tank ? { x: tank.x, y: tank.y } : null;
+  }
+}
+
+/**
+ * Met sur le fil ce qui est destiné à un joueur.
+ *
+ * ⚠ La sérialisation doit avoir lieu **à l'émission**, pas à la livraison.
+ * `stripTiles` ne fait qu'un étalement superficiel : un `Outgoing` conservé tel
+ * quel dans une file d'attente continue de pointer sur les tableaux vivants de
+ * la salle, et le « vieil instantané » livré six pas plus tard contient en fait
+ * l'état courant. Le client rejouait alors ses intentions sur un état trop
+ * récent et bondissait d'un aller-retour complet. Le vrai serveur encode au
+ * moment de l'envoi ; le test doit faire pareil.
+ */
+function toWire(outgoing: Outgoing[], playerId: string): string[] {
+  return outgoing
+    .filter((entry) => entry.to === null || entry.to === playerId)
+    .map((entry) => encode(entry.message));
+}
+
+/**
+ * Lien réseau simulé : retard fixe et pertes reproductibles.
+ *
+ * Les pertes sont périodiques et non tirées au hasard : un test de réseau qui
+ * échoue une fois sur vingt n'apprend rien à personne.
+ */
+class Link<T> {
+  readonly #queue: Array<{ at: number; payload: T }> = [];
+  #sent = 0;
+
+  constructor(
+    private readonly delayTicks: number,
+    /** Une perte toutes les N émissions. 0 pour un lien parfait. */
+    private readonly dropOneIn = 0,
+  ) {}
+
+  send(now: number, payload: T): void {
+    this.#sent++;
+    if (this.dropOneIn > 0 && this.#sent % this.dropOneIn === 0) return;
+    this.#queue.push({ at: now + this.delayTicks, payload });
+  }
+
+  /** Retire et rend tout ce qui est arrivé à échéance. */
+  deliver(now: number): T[] {
+    const ready = this.#queue.filter((entry) => entry.at <= now);
+    for (const entry of ready) this.#queue.splice(this.#queue.indexOf(entry), 1);
+    return ready.map((entry) => entry.payload);
+  }
+}
+
+describe('autorité du serveur', () => {
+  test('la salle installe un tank par joueur', () => {
+    const room = openRoom('a', 'b', 'c');
+    const world = room.world!;
+
+    const players = world.tanks.filter((tank) => tank.playerId !== null);
+    expect(players).toHaveLength(3);
+    expect(new Set(players.map((tank) => tank.playerId))).toEqual(new Set(['a', 'b', 'c']));
+  });
+
+  test('le protocole ne transporte aucune position', () => {
+    // Le seul message qu'un client peut envoyer sur le gameplay est une
+    // intention. Une position falsifiée n'a aucun champ où se loger : c'est
+    // structurel, pas une validation qu'on pourrait oublier.
+    const forged = { t: 'input', seq: 0, input: { ...RIGHT, x: 999, y: 999 } };
+    const room = openRoom('a');
+
+    const before = room.world!.tanks[0]!.x;
+    room.input('a', decode<ClientMessage>(encode(forged as ClientMessage)) as never);
+    room.step();
+
+    // Le tank a bougé selon la règle, d'une fraction de tuile — pas jusqu'à 999.
+    const after = room.world!.tanks[0]!.x;
+    expect(after).toBeGreaterThan(before);
+    expect(after - before).toBeLessThan(1);
+  });
+
+  test('une intention en retard ou dupliquée est ignorée', () => {
+    const room = openRoom('a');
+
+    room.input('a', { t: 'input', seq: 5, input: RIGHT });
+    room.step();
+
+    const afterFirst = room.world!.tanks[0]!.x;
+
+    // Même numéro : c'est un doublon. Un numéro plus ancien : c'est un message
+    // arrivé après son successeur. Appliquer l'un ou l'autre ferait reculer le tank.
+    room.input('a', { t: 'input', seq: 5, input: LEFT });
+    room.input('a', { t: 'input', seq: 2, input: LEFT });
+    room.step();
+
+    // La dernière intention connue est rejouée : le tank continue vers la droite.
+    expect(room.world!.tanks[0]!.x).toBeGreaterThan(afterFirst);
+  });
+
+  test('un message illisible ne fait rien tomber', () => {
+    expect(decode('ceci n\'est pas du JSON')).toBeNull();
+    expect(decode('[]')).toBeNull();
+    expect(decode('{"pas_de_type":1}')).toBeNull();
+    expect(decode(42)).toBeNull();
+  });
+});
+
+describe('tampon anti-gigue', () => {
+  test('un tampon vide rejoue la dernière intention', () => {
+    // Les intentions n'arrivent pas à intervalle régulier. Sans ce report, le
+    // tank s'arrêterait à chaque trou dans le flux — un déplacement est un état
+    // maintenu, pas un évènement.
+    const room = openRoom('a');
+    room.input('a', { t: 'input', seq: 0, input: RIGHT });
+
+    room.step();
+    const afterFirst = room.world!.tanks[0]!.x;
+
+    room.step();
+    room.step();
+
+    expect(room.world!.tanks[0]!.x).toBeGreaterThan(afterFirst);
+  });
+
+  test('une rafale est absorbée sans être jetée', () => {
+    const room = openRoom('a');
+
+    // Cinq intentions d'un bloc, comme après un hoquet du réseau.
+    for (let seq = 0; seq < 5; seq++) {
+      room.input('a', { t: 'input', seq, input: RIGHT });
+    }
+
+    // Cinq intentions consommées en quatre pas, aucune jetée : au-delà de la
+    // profondeur visée, le serveur en prend deux par pas pour résorber l'avance
+    // plutôt que de laisser la latence s'installer.
+    for (let index = 0; index < 4; index++) room.step();
+
+    const snapshot = snapshotsFor(room.broadcast(), 'a')[0]!;
+    expect(snapshot.ack).toBe(4);
+  });
+
+  test('une inondation ne fait pas gonfler la salle sans fin', () => {
+    const room = openRoom('a');
+    for (let seq = 0; seq < 500; seq++) {
+      room.input('a', { t: 'input', seq, input: RIGHT });
+    }
+
+    // Le tampon est plafonné : les plus anciennes intentions sont abandonnées,
+    // et le serveur reste sur les plus récentes.
+    room.step();
+    const snapshot = snapshotsFor(room.broadcast(), 'a')[0]!;
+    expect(snapshot.ack).toBeGreaterThan(400);
+  });
+});
+
+describe('diffusion', () => {
+  test('le terrain part une fois, puis seulement au changement', () => {
+    const room = openRoom('a');
+
+    const first = room.broadcast();
+    expect(first.filter((entry) => entry.message.t === 'terrain')).toHaveLength(1);
+
+    const second = room.broadcast();
+    expect(second.filter((entry) => entry.message.t === 'terrain')).toHaveLength(0);
+  });
+
+  test('chaque joueur reçoit son propre accusé et son propre tank', () => {
+    const room = openRoom('a', 'b');
+
+    room.input('a', { t: 'input', seq: 7, input: RIGHT });
+    room.step();
+
+    const outgoing = room.broadcast();
+    const toA = snapshotsFor(outgoing, 'a')[0]!;
+    const toB = snapshotsFor(outgoing, 'b')[0]!;
+
+    expect(toA.ack).toBe(7);
+    expect(toB.ack).toBe(-1);
+    expect(toA.yourTankId).toBe(room.tankIdOf('a')!);
+    expect(toB.yourTankId).toBe(room.tankIdOf('b')!);
+    expect(toA.yourTankId).not.toBe(toB.yourTankId);
+  });
+
+  test('l\'instantané voyage sans les tuiles, et se recompose à l\'identique', () => {
+    // Le terrain est de loin le plus gros objet de l'état ; le renvoyer vingt
+    // fois par seconde pour rien multiplierait le débit.
+    const room = openRoom('a');
+    const world = room.world!;
+
+    const partial = stripTiles(world);
+    expect('tiles' in partial.grid).toBe(false);
+
+    const restored = withTiles(
+      JSON.parse(JSON.stringify(partial)) as typeof partial,
+      world.grid.tiles,
+    );
+    expect(hashWorld(restored)).toBe(hashWorld(world));
+  });
+});
+
+describe('convergence client / serveur', () => {
+  /**
+   * Fait tourner une partie complète à travers un lien simulé.
+   *
+   * Le retard s'applique dans les deux sens, comme un vrai aller-retour.
+   */
+  function play(options: {
+    ticks: number;
+    delayTicks: number;
+    dropOneIn?: number;
+    inputAt(tick: number): InputCommand;
+  }): { room: Room; client: TestClient; maxJump: number } {
+    const room = openRoom('a');
+    const client = new TestClient();
+
+    const upstream = new Link<{ seq: number; input: InputCommand }>(
+      options.delayTicks,
+      options.dropOneIn ?? 0,
+    );
+    const downstream = new Link<string[]>(options.delayTicks);
+
+    const snapshotEvery = 3;
+    let maxJump = 0;
+
+    for (let now = 0; now < options.ticks; now++) {
+      const input = options.inputAt(now);
+
+      const before = client.localTank();
+
+      // Côté client : on émet, puis on prédit sans attendre.
+      const seq = client.nextSeq();
+      upstream.send(now, { seq, input });
+      client.reconciler.predict(seq, input);
+
+      // Côté serveur : on applique ce qui est arrivé, puis on avance.
+      for (const message of upstream.deliver(now)) {
+        room.input('a', { t: 'input', seq: message.seq, input: message.input });
+      }
+      room.step();
+
+      if (now % snapshotEvery === 0) downstream.send(now, toWire(room.broadcast(), 'a'));
+      for (const batch of downstream.deliver(now)) client.receiveWire(batch);
+
+      const after = client.localTank();
+      if (before && after) {
+        maxJump = Math.max(maxJump, Math.hypot(after.x - before.x, after.y - before.y));
+      }
+    }
+
+    return { room, client, maxJump };
+  }
+
+  test('sans latence, le client retombe exactement sur l\'état serveur', () => {
+    const { room, client } = play({
+      ticks: 60,
+      delayTicks: 0,
+      inputAt: () => RIGHT,
+    });
+
+    // Un dernier instantané, pour que rien ne reste en attente : les
+    // instantanés ne partent qu'un pas sur trois.
+    client.receive(room.broadcast(), 'a');
+
+    // Toutes les intentions sont confirmées : le monde prédit doit être le
+    // monde serveur, au bit près.
+    expect(client.reconciler.pendingCount).toBe(0);
+    expect(hashWorld(client.reconciler.world!)).toBe(hashWorld(room.world!));
+  });
+
+  test('à 100 ms de latence, le tank local ne saute jamais', () => {
+    // Six pas de retard dans chaque sens : un aller-retour de 200 ms, soit
+    // largement au-delà de ce qu'une partie normale rencontre.
+    const { maxJump, client } = play({
+      ticks: 240,
+      delayTicks: 6,
+      inputAt: (tick) => (tick % 40 < 20 ? RIGHT : LEFT),
+    });
+
+    // Le tank ne doit jamais avancer de plus d'un pas entre deux images : sur un
+    // lien sans perte, la prédiction et l'autorité appliquent exactement les
+    // mêmes intentions, donc la correction est nulle. Une correction qui
+    // déplacerait visiblement le tank serait pire que la latence qu'elle compense.
+    expect(maxJump).toBeLessThan(2 * MOVEMENT_STEP_TILES);
+    // Et la prédiction ne s'emballe pas : il reste l'aller-retour en attente,
+    // pas une seconde entière d'intentions.
+    expect(client.reconciler.pendingCount).toBeLessThan(20);
+  });
+
+  test('avec 5 % de pertes, la divergence ne s\'installe pas', () => {
+    const { room, client, maxJump } = play({
+      ticks: 300,
+      delayTicks: 6,
+      dropOneIn: 20,
+      inputAt: (tick) => (tick % 40 < 20 ? RIGHT : LEFT),
+    });
+
+    // Une intention perdue coûte exactement un pas de correction — soit deux
+    // pas de déplacement sur l'image concernée, moins de deux pixels à l'écran.
+    // C'est le plancher : on ne peut pas rattraper une intention que le serveur
+    // n'a jamais reçue.
+    expect(maxJump).toBeLessThan(3 * MOVEMENT_STEP_TILES);
+
+    // Une intention perdue est une intention que le serveur n'appliquera jamais :
+    // les deux positions ne peuvent pas coïncider au bit près. Ce qui compte est
+    // que l'écart reste borné au lieu de s'accumuler.
+    const server = room.world!.tanks.find((tank) => tank.playerId === 'a')!;
+    const predicted = client.localTank()!;
+
+    expect(Math.hypot(predicted.x - server.x, predicted.y - server.y)).toBeLessThan(1);
+  });
+
+  test('les intentions non confirmées sont rejouées, pas perdues', () => {
+    const room = openRoom('a');
+    const client = new TestClient();
+
+    client.reconciler.predict(client.nextSeq(), NEUTRAL_INPUT);
+    room.input('a', { t: 'input', seq: 0, input: NEUTRAL_INPUT });
+    room.step();
+    client.receive(room.broadcast(), 'a');
+
+    const startX = client.localTank()!.x;
+
+    // Cinq intentions dont le serveur n'a pas encore accusé réception.
+    for (let index = 0; index < 5; index++) client.reconciler.predict(client.nextSeq(), RIGHT);
+    const predictedX = client.localTank()!.x;
+    expect(predictedX).toBeGreaterThan(startX);
+
+    // Le serveur renvoie un état plus ancien : le client doit le reprendre,
+    // puis rejouer ses cinq intentions — et retomber à la même position.
+    client.receive(room.broadcast(), 'a');
+
+    expect(client.reconciler.pendingCount).toBe(5);
+    expect(client.localTank()!.x).toBeCloseTo(predictedX, 9);
+  });
+
+  test('le client ne rejoue pas ce que le serveur a déjà appliqué', () => {
+    const room = openRoom('a');
+    const client = new TestClient();
+
+    for (let seq = 0; seq < 10; seq++) {
+      client.reconciler.predict(seq, RIGHT);
+      room.input('a', { t: 'input', seq, input: RIGHT });
+      room.step();
+    }
+
+    client.receive(room.broadcast(), 'a');
+
+    // Sans ce filtrage, les dix intentions seraient appliquées deux fois et le
+    // tank ferait un bond en avant à chaque instantané.
+    expect(client.reconciler.pendingCount).toBe(0);
+    expect(client.localTank()!.x).toBeCloseTo(
+      room.world!.tanks.find((tank) => tank.playerId === 'a')!.x,
+      9,
+    );
+  });
+});
+
+describe('résilience', () => {
+  test('la déconnexion arrête le tank sans arrêter la partie', () => {
+    const room = openRoom('a', 'b');
+    room.input('a', { t: 'input', seq: 0, input: RIGHT });
+    room.step();
+
+    room.disconnect('a');
+    const stoppedAt = room.world!.tanks.find((tank) => tank.playerId === 'a')!.x;
+
+    for (let index = 0; index < 10; index++) room.step();
+
+    // Sans ce garde-fou, le tank continuerait sur sa lancée, touche enfoncée,
+    // sans personne derrière.
+    expect(room.world!.tanks.find((tank) => tank.playerId === 'a')!.x).toBe(stoppedAt);
+    // Et la simulation, elle, continue pour tout le monde.
+    expect(room.world!.tick).toBeGreaterThan(10);
+  });
+
+  test('le tank d\'un joueur parti finit par disparaître', () => {
+    const room = openRoom('a', 'b');
+    room.disconnect('a');
+
+    // Le délai de grâce couvre une coupure passagère ; au-delà, l'épave ne doit
+    // pas encaisser les tirs à la place des autres.
+    for (let index = 0; index < 60 * 11; index++) room.step();
+
+    expect(room.world!.tanks.some((tank) => tank.playerId === 'a')).toBe(false);
+    expect(room.world!.tanks.some((tank) => tank.playerId === 'b')).toBe(true);
+  });
+
+  test('l\'IA continue quand tous les joueurs sont partis', () => {
+    // L'ancienne version désignait `player1` maître de l'IA : son départ
+    // arrêtait net les ennemis. Ici l'IA appartient à la salle.
+    const room = openRoom('a');
+    room.disconnect('a');
+
+    const enemiesBefore = room.world!.tanks.filter((tank) => tank.playerId === null).length;
+    for (let index = 0; index < 120; index++) room.step();
+
+    expect(room.world!.tanks.filter((tank) => tank.playerId === null)).toHaveLength(
+      enemiesBefore,
+    );
+  });
+
+  test('une reconnexion reprend le siège', () => {
+    const room = openRoom('a', 'b');
+    const tankId = room.tankIdOf('a')!;
+
+    room.disconnect('a');
+    for (let index = 0; index < 60; index++) room.step();
+
+    room.join('a', 'a');
+    expect(room.tankIdOf('a')).toBe(tankId);
+  });
+
+  test('un joueur qui arrive en cours de partie reçoit un tank', () => {
+    const room = openRoom('a');
+    for (let index = 0; index < 30; index++) room.step();
+
+    room.join('c', 'c');
+    expect(room.tankIdOf('c')).toBeDefined();
+    expect(room.world!.tanks.filter((tank) => tank.playerId !== null)).toHaveLength(2);
+  });
+});
+
+describe('lobby', () => {
+  test('l\'arrivée annonce la table de réglages et la liste des joueurs', () => {
+    const room = new Room('salon');
+    const outgoing = room.join('a', 'Aurélien');
+
+    const welcome = outgoing.find((entry) => entry.message.t === 'welcome')!;
+    expect(welcome.to).toBe('a');
+    // La prédiction doit tourner sur exactement les constantes de l'autorité.
+    expect((welcome.message as { tuning: unknown }).tuning).toBeDefined();
+
+    const lobby = outgoing.find((entry) => entry.message.t === 'lobby')!;
+    expect(lobby.to).toBeNull();
+    expect((lobby.message as { players: Array<{ name: string }> }).players[0]!.name).toBe(
+      'Aurélien',
+    );
+  });
+
+  test('démarrer deux fois n\'ouvre pas deux parties', () => {
+    const room = new Room('salon');
+    room.join('a', 'a');
+
+    room.start();
+    const world = room.world;
+    room.start();
+
+    expect(room.world).toBe(world);
+  });
+
+  test('un message de type inconnu est simplement ignoré', () => {
+    const message = decode<ServerMessage>(encode({ t: 'bye', reason: 'test' }));
+    expect(message?.t).toBe('bye');
+  });
+});


### PR DESCRIPTION
Closes #13.

**Aucun remaniement du gameplay** — c'était tout l'objet de l'architecture. Le coeur étant pur, déterministe et sérialisable, le serveur exécute exactement le même `tick()` que le client. Il n'existe toujours qu'une seule implémentation de la physique.

## Ce qui disparaît

L'ancien serveur relayait du JSON sans jamais le lire, et désignait `player1` maître de l'IA : il diffusait des paquets `enemyMove` que les autres appliquaient aveuglément. Trois conséquences — les états divergeaient à la première perte de paquet, la position d'un joueur était ce qu'il déclarait, et la déconnexion de `player1` arrêtait l'IA.

Ici, **la salle est la seule chose qui existe**. Elle détient le monde, exécute toute l'IA, et n'accepte des clients que des intentions.

## Autorité

Le protocole ne transporte **aucune position**. C'est structurel, pas une validation qu'on pourrait oublier : un test envoie une intention avec des coordonnées falsifiées, et elles n'ont simplement aucun champ où se loger.

Le serveur transmet sa table de réglages à la connexion — prédiction et autorité tournent sur exactement les mêmes constantes. Sans ça, la prédiction dériverait à chaque pas et se ferait corriger en permanence.

## Les deux régimes d'affichage

```
tank local  ──► monde prédit          (immédiat)
le reste    ──► tampon d'instantanés  (100 ms de retard, lissé)
```

Le tank local s'applique au pas où il est saisi ; à chaque instantané le client adopte l'état serveur puis **rejoue ses intentions non confirmées**. Le rejeu passe par `tick()` complet et non par une intégration allégée — une seconde implémentation du déplacement dériverait de la première, ce qu'on a passé huit issues à éliminer.

Tout le reste est interpolé, **jamais prédit**. Le client ignore les intentions des autres joueurs : une prédiction serait une invention, que chaque instantané corrigerait par une téléportation. Le prix des 100 ms, c'est de voir les autres légèrement dans le passé ; le prix de la prédiction, ce serait de les voir sauter. Le second se remarque beaucoup plus.

## Mise en commun plutôt que duplication

| Module | Pourquoi il remonte dans `shared/` |
|---|---|
| `CampaignRunner` | serveur et client solo enchaînent les missions avec le même code |
| `timestep` | client et serveur doivent consommer le temps réel de la même façon — sinon le serveur avance de 61 pas quand le client en compte 60, et la réconciliation corrige sans fin un écart qui ne vient pas du réseau |

## Places de départ en co-op

Les vingt arènes n'ont qu'un point de départ : l'original est un jeu solo. Plutôt que de dessiner à la main trois départs de plus sur vingt grilles — vingt occasions de placer un coéquipier dans un mur ou sous le nez d'un tank vert — les places manquantes sont dérivées par parcours en largeur déterministe autour du départ déclaré, dont elles héritent les garanties d'accessibilité et de distance aux ennemis.

Avec **deux tuiles d'écart minimum** : la première version prenait les tuiles voisines immédiates, et les boîtes de collision se touchaient. C'est d'ailleurs comme ça que je l'ai vu — mon premier essai à deux navigateurs montrait un tank qui n'avançait que de 0,16 tuile, ce qui ressemblait à une panne réseau et n'était qu'une collision entre coéquipiers.

## Débit

L'instantané voyage **sans les tuiles du terrain**, qui partent à part quand la version change. C'est de loin le plus gros objet de l'état, et il ne bouge qu'à la destruction d'un bloc ou au changement de mission.

L'horloge des instantanés est celle de la salle, monotone — et non `world.tick`, qui repart de zéro à chaque mission : une horloge qui recule ferait sauter l'interpolation à chaque changement d'arène.

## Deux défauts trouvés dans les tests eux-mêmes

Les deux tiennent au fait que `stripTiles` ne fait qu'un **étalement superficiel**.

1. **Sans aller-retour JSON, le client partageait les tableaux du serveur.** Il mutait l'état de l'autorité en rejouant ses intentions, et le test de convergence vérifiait que deux références égales sont égales — c'est-à-dire rien.
2. **Pire : un `Outgoing` conservé dans une file d'attente continue de pointer sur les tableaux vivants de la salle.** Le « vieil instantané » livré six pas plus tard contenait en fait l'état courant ; le client rejouait ses intentions par-dessus un état trop récent et bondissait d'un aller-retour complet. Le vrai serveur encode à l'émission — le harnais le fait désormais aussi.

## Vérification

**Unitaire, sur un lien simulé** (retard fixe et pertes périodiques, pas tirées au hasard — un test réseau qui échoue une fois sur vingt n'apprend rien) :

- sans latence, le client retombe sur le **hash** du serveur ;
- à 100 ms, le tank local ne saute jamais de plus d'un pas de déplacement ;
- à 5 % de pertes, l'écart reste **borné** au lieu de s'accumuler — une intention perdue coûte exactement un pas de correction, soit moins de deux pixels, et c'est le plancher : on ne rattrape pas ce que le serveur n'a jamais reçu.

**Bout-en-bout, deux navigateurs** : partie partagée, déplacement vu par l'autre, réponse immédiate du tank local en trois images, déconnexion sans effet sur l'IA, salons étanches.

⚠ Chromium ralentit `requestAnimationFrame` dans les onglets en arrière-plan : la page qui n'a pas le dessus tombe à quelques images par seconde et cesse d'émettre des intentions — trait pour trait une panne réseau. Les drapeaux de lancement le désactivent, sinon les tests de co-op échouent pour une raison sans rapport avec le jeu.

366 tests unitaires, 33 bout-en-bout, typecheck propre.

## Utilisation

```
bun run coop     # construit le client et sert le tout sur :3000
```

puis `http://localhost:3000/?enligne=1&salon=x&nom=y` dans deux fenêtres. En développement, `bun run dev` et `bun run serve` côte à côte suffisent — le client trouve le serveur tout seul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
